### PR TITLE
Reyna logging

### DIFF
--- a/src/reyna/Reyna.Facts/GivenAUnityHelper.cs
+++ b/src/reyna/Reyna.Facts/GivenAUnityHelper.cs
@@ -41,8 +41,9 @@ namespace Reyna.Facts
             Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IConnectionInfo) && r.MappedToType == typeof(ConnectionInfo)));
             Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IBlackoutTime) && r.MappedToType == typeof(BlackoutTime)));
             Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IWebRequest) && r.MappedToType == typeof(ReynaWebRequest)));
+            Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IReynaLogger) && r.MappedToType == typeof(IReynaLogger)));
 
-            Assert.Equal(17, container.Registrations.Count()); // Always 1 ahead due to the default lifetime manager registration
+            Assert.Equal(18, container.Registrations.Count()); // Always 1 ahead due to the default lifetime manager registration
         }
     }
 }

--- a/src/reyna/Reyna.Facts/Http/GivenAnHttpClient.cs
+++ b/src/reyna/Reyna.Facts/Http/GivenAnHttpClient.cs
@@ -11,13 +11,14 @@
         private HttpClient httpClient;
         private Mock<IConnectionManager> connectionManager;
         private Mock<IWebRequest> webRequest;
+        private readonly Mock<IReynaLogger> loggerMock;
 
         public GivenAnHttpClient()
         {
             this.connectionManager = new Mock<IConnectionManager>();
             this.webRequest = new Mock<IWebRequest>();
-
-            this.httpClient = new HttpClient(connectionManager.Object, this.webRequest.Object);
+            this.loggerMock = new Mock<IReynaLogger>();
+            this.httpClient = new HttpClient(connectionManager.Object, webRequest.Object, loggerMock.Object);
         }
 
         [Theory]

--- a/src/reyna/Reyna.Facts/Services/GivenAForwardService.cs
+++ b/src/reyna/Reyna.Facts/Services/GivenAForwardService.cs
@@ -16,6 +16,7 @@
         private Mock<IHttpClient> httpClient;
         private Mock<INetworkStateService> networkStateService;
         private Mock<IRepository> persistentStore;
+        private readonly Mock<IReynaLogger> loggerMock;
 
         public GivenAForwardService()
         {
@@ -23,8 +24,9 @@
             this.httpClient = new Mock<IHttpClient>();
             this.networkStateService = new Mock<INetworkStateService>();
             this.persistentStore = new Mock<IRepository>();
+            this.loggerMock = new Mock<IReynaLogger>();
 
-            this.service = new ForwardService(this.waitHandle.Object);
+            this.service = new ForwardService(this.waitHandle.Object, loggerMock.Object);
         }
 
         [Fact]

--- a/src/reyna/Reyna.Facts/Services/GivenAReynaService.cs
+++ b/src/reyna/Reyna.Facts/Services/GivenAReynaService.cs
@@ -24,6 +24,7 @@
         private Mock<IForwardService> forwardService; 
         private Mock<INetworkStateService> networkStateService;
         private Mock<IEncryptionChecker> encryptionChecker;
+        private Mock<IReynaLogger> reynaLogger;
 
         public GivenAReynaService()
         {
@@ -36,6 +37,7 @@
             this.storeService = this.unity.mockStoreService;
             this.forwardService = this.unity.mockForwardService;
             this.encryptionChecker = this.unity.mockEncryptionChecker;
+            this.reynaLogger = this.unity.mockReynaLogger;
         }
 
         [Fact]
@@ -48,6 +50,7 @@
             Assert.Same(this.networkStateService.Object, this.service.NetworkStateService);
             Assert.Same(this.forwardService.Object, this.service.ForwardService);
             Assert.Same(this.encryptionChecker.Object, this.service.EncryptionChecker);
+            Assert.Same(this.reynaLogger.Object, this.service.Logger);
         }
 
         [Fact]

--- a/src/reyna/Reyna.Facts/TestUnityHelper.cs
+++ b/src/reyna/Reyna.Facts/TestUnityHelper.cs
@@ -20,6 +20,7 @@
         internal Mock<IStoreService> mockStoreService = new Mock<IStoreService>();
         internal Mock<IForwardService> mockForwardService = new Mock<IForwardService>();
         internal Mock<IEncryptionChecker> mockEncryptionChecker = new Mock<IEncryptionChecker>();
+        internal Mock<IReynaLogger> mockReynaLogger = new Mock<IReynaLogger>();
 
         public IUnityContainer GetContainer()
         {
@@ -33,6 +34,7 @@
             container.RegisterInstance<IStoreService>(this.mockStoreService.Object);
             container.RegisterInstance<IForwardService>(this.mockForwardService.Object);
             container.RegisterInstance<IEncryptionChecker>(this.mockEncryptionChecker.Object);
+            container.RegisterInstance<IReynaLogger>(this.mockReynaLogger.Object);
 
             return container;
         }

--- a/src/reyna/Reyna/Http/HttpClient.cs
+++ b/src/reyna/Reyna/Http/HttpClient.cs
@@ -1,4 +1,5 @@
-﻿namespace Reyna
+﻿
+namespace Reyna
 {
     using System;
     using System.Net;
@@ -12,11 +13,13 @@
     {
         public IConnectionManager ConnectionManager { get; set; }
         private IWebRequest webRequest;
+        private IReynaLogger Logger;
 
-        public HttpClient(IConnectionManager connectionManager, IWebRequest webRequest)
+        public HttpClient(IConnectionManager connectionManager, IWebRequest webRequest, IReynaLogger logger)
         {
             this.ConnectionManager = connectionManager;
             this.webRequest = webRequest;
+            Logger = logger;
         }
 
         public Result CanSend()
@@ -28,9 +31,12 @@
         {
             try
             {
+                Logger.Info("Reyna.HttpClient Post id {0} url {1} body length {2}", message.Id,message.Url,message.Body.Length);
+
                 Result result = CanSend();
                 if (result != Result.Ok)
                 {
+                    Logger.Info("Reyna.HttpClient Post cannot send");
                     return result;
                 }
 
@@ -52,8 +58,10 @@
 
                 return this.webRequest.Send(message.Body);
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Logger.Error("Reyna.HttpClient Post {0}",e);
+               
                 return Result.PermanentError;
             }
         }

--- a/src/reyna/Reyna/Http/ReynaWebRequest.cs
+++ b/src/reyna/Reyna/Http/ReynaWebRequest.cs
@@ -76,7 +76,7 @@ namespace Reyna
             {
                 var response = webException.Response as HttpWebResponse;
                 statusCode = this.GetStatusCode(response);
-                Logger.Error("ReynaWebRequest.Send Error {0} Status code {1}", webException.ToString(), statusCode);
+                Logger.Error("ReynaWebRequest.Send Error {0} Status code {1}", webException, statusCode);
             }
 
             return HttpStatusCodeExtensions.ToResult(statusCode);

--- a/src/reyna/Reyna/Http/ReynaWebRequest.cs
+++ b/src/reyna/Reyna/Http/ReynaWebRequest.cs
@@ -8,8 +8,15 @@ namespace Reyna
 
     public class ReynaWebRequest : IWebRequest
     {
+        private IReynaLogger Logger { get; set; }
+
         private HttpWebRequest httpRequest;
-        
+
+        public ReynaWebRequest(IReynaLogger logger)
+        {
+            Logger = logger;
+        }
+
         public void CreateRequest(Uri uri)
         {
             this.httpRequest = WebRequest.Create(uri) as HttpWebRequest;
@@ -26,7 +33,6 @@ namespace Reyna
             {
                 this.httpRequest.Method = value;
             }
-
         }
 
         public void AddHeader(string key, string value) 
@@ -70,6 +76,7 @@ namespace Reyna
             {
                 var response = webException.Response as HttpWebResponse;
                 statusCode = this.GetStatusCode(response);
+                Logger.Error("ReynaWebRequest.Send Error {0} Status code {1}", webException.ToString(), statusCode);
             }
 
             return HttpStatusCodeExtensions.ToResult(statusCode);
@@ -84,6 +91,5 @@ namespace Reyna
 
             return response.StatusCode;
         }
-
     }
 }

--- a/src/reyna/Reyna/Logging/ILogDelegate.cs
+++ b/src/reyna/Reyna/Logging/ILogDelegate.cs
@@ -1,0 +1,7 @@
+﻿namespace Reyna.Interfaces
+{
+    public interface ILogDelegate
+    {
+        void Log(uint logLevel, string msg, params object[] args);
+    }
+}

--- a/src/reyna/Reyna/Logging/ILoggerInterface.cs
+++ b/src/reyna/Reyna/Logging/ILoggerInterface.cs
@@ -1,0 +1,7 @@
+﻿namespace Reyna.Interfaces
+{
+    public interface ILoggerInterface
+    {
+        void LogDelegate(uint logLevel, string msg, params object[] args);
+    }
+}

--- a/src/reyna/Reyna/Logging/ILoggerInterface.cs
+++ b/src/reyna/Reyna/Logging/ILoggerInterface.cs
@@ -1,7 +1,0 @@
-﻿namespace Reyna.Interfaces
-{
-    public interface ILoggerInterface
-    {
-        void LogDelegate(uint logLevel, string msg, params object[] args);
-    }
-}

--- a/src/reyna/Reyna/Logging/IReynaLogger.cs
+++ b/src/reyna/Reyna/Logging/IReynaLogger.cs
@@ -1,0 +1,14 @@
+﻿
+namespace Reyna
+{
+    public interface IReynaLogger
+    {
+        void Initialise(ReynaLogger.LogHandler logger);
+
+        void Error(string msg, params object[] args);
+        void Warn(string format, params object[] args);
+        void Debug(string format, params object[] args);
+        void Info(string msg, params object[] args);
+        void Verbose(string format, params object[] args);
+    } 
+}

--- a/src/reyna/Reyna/Logging/IReynaLogger.cs
+++ b/src/reyna/Reyna/Logging/IReynaLogger.cs
@@ -1,11 +1,11 @@
 ﻿
-using Reyna.Interfaces;
-
 namespace Reyna
 {
+    using Interfaces;
+
     public interface IReynaLogger
     {
-        void Initialise(ILoggerInterface logger);
+        void Initialise(ILogDelegate logger);
 
         void Error(string msg, params object[] args);
         void Warn(string format, params object[] args);

--- a/src/reyna/Reyna/Logging/IReynaLogger.cs
+++ b/src/reyna/Reyna/Logging/IReynaLogger.cs
@@ -1,9 +1,11 @@
 ﻿
+using Reyna.Interfaces;
+
 namespace Reyna
 {
     public interface IReynaLogger
     {
-        void Initialise(ReynaLogger.LogHandler logger);
+        void Initialise(ILoggerInterface logger);
 
         void Error(string msg, params object[] args);
         void Warn(string format, params object[] args);

--- a/src/reyna/Reyna/Logging/ReynaLogger.cs
+++ b/src/reyna/Reyna/Logging/ReynaLogger.cs
@@ -1,8 +1,8 @@
 ﻿
-using Reyna.Interfaces;
-
 namespace Reyna
 {
+    using Interfaces;
+
     public class ReynaLogger : IReynaLogger
     {
         private const uint LogError =   0;
@@ -11,14 +11,14 @@ namespace Reyna
         private const uint LogInfo =    3;
         private const uint LogVerbose = 4;
 
-        private ILoggerInterface LogHandler;
+        private ILogDelegate LogHandler;
 
         public ReynaLogger()
         {
             LogHandler = null;
         }
 
-        public void Initialise(ILoggerInterface logger)
+        public void Initialise(ILogDelegate logger)
         {
             LogHandler = logger;
         }
@@ -26,31 +26,31 @@ namespace Reyna
         public void Error(string msg, params object[] args)
         {
             if (LogHandler != null)
-                LogHandler.LogDelegate(LogError, msg, args);
+                LogHandler.Log(LogError, msg, args);
         }
 
         public void Warn(string msg, params object[] args)
         {
             if (LogHandler != null)
-                LogHandler.LogDelegate(LogWarn, msg, args);
+                LogHandler.Log(LogWarn, msg, args);
         }
 
         public void Debug(string msg, params object[] args)
         {
             if (LogHandler != null)
-                LogHandler.LogDelegate(LogDebug, msg, args);
+                LogHandler.Log(LogDebug, msg, args);
         }
 
         public void Info(string msg, params object[] args)
         {
             if (LogHandler != null)
-                LogHandler.LogDelegate(LogInfo, msg, args);
+                LogHandler.Log(LogInfo, msg, args);
         }
    
         public void Verbose(string msg, params object[] args)
         {
             if (LogHandler != null)
-                LogHandler.LogDelegate(LogVerbose, msg, args);
+                LogHandler.Log(LogVerbose, msg, args);
         }
     }
 }

--- a/src/reyna/Reyna/Logging/ReynaLogger.cs
+++ b/src/reyna/Reyna/Logging/ReynaLogger.cs
@@ -1,4 +1,6 @@
 ﻿
+using Reyna.Interfaces;
+
 namespace Reyna
 {
     public class ReynaLogger : IReynaLogger
@@ -9,48 +11,46 @@ namespace Reyna
         private const uint LogInfo =    3;
         private const uint LogVerbose = 4;
 
-        public delegate void LogHandler(uint level, string format, params object[] args);
-
-        private LogHandler logHandler;
+        private ILoggerInterface LogHandler;
 
         public ReynaLogger()
         {
-            logHandler = null;
+            LogHandler = null;
         }
 
-        public void Initialise(LogHandler logger)
+        public void Initialise(ILoggerInterface logger)
         {
-            logHandler = logger;
+            LogHandler = logger;
         }
 
         public void Error(string msg, params object[] args)
         {
-            if (logHandler != null)
-                logHandler(LogError, msg, args);
+            if (LogHandler != null)
+                LogHandler.LogDelegate(LogError, msg, args);
         }
 
         public void Warn(string msg, params object[] args)
         {
-            if (logHandler != null)
-                logHandler(LogWarn, msg, args);
+            if (LogHandler != null)
+                LogHandler.LogDelegate(LogWarn, msg, args);
         }
 
         public void Debug(string msg, params object[] args)
         {
-            if (logHandler != null)
-                logHandler(LogDebug, msg, args);
+            if (LogHandler != null)
+                LogHandler.LogDelegate(LogDebug, msg, args);
         }
 
         public void Info(string msg, params object[] args)
         {
-            if (logHandler != null)
-                logHandler(LogInfo, msg, args);
+            if (LogHandler != null)
+                LogHandler.LogDelegate(LogInfo, msg, args);
         }
    
         public void Verbose(string msg, params object[] args)
         {
-            if (logHandler != null)
-                logHandler(LogVerbose, msg, args);
+            if (LogHandler != null)
+                LogHandler.LogDelegate(LogVerbose, msg, args);
         }
     }
 }

--- a/src/reyna/Reyna/Logging/ReynaLogger.cs
+++ b/src/reyna/Reyna/Logging/ReynaLogger.cs
@@ -1,0 +1,56 @@
+﻿
+namespace Reyna
+{
+    public class ReynaLogger : IReynaLogger
+    {
+        private const uint LogError =   0;
+        private const uint LogWarn =    1;
+        private const uint LogDebug =   2;
+        private const uint LogInfo =    3;
+        private const uint LogVerbose = 4;
+
+        public delegate void LogHandler(uint level, string format, params object[] args);
+
+        private LogHandler logHandler;
+
+        public ReynaLogger()
+        {
+            logHandler = null;
+        }
+
+        public void Initialise(LogHandler logger)
+        {
+            logHandler = logger;
+        }
+
+        public void Error(string msg, params object[] args)
+        {
+            if (logHandler != null)
+                logHandler(LogError, msg, args);
+        }
+
+        public void Warn(string msg, params object[] args)
+        {
+            if (logHandler != null)
+                logHandler(LogWarn, msg, args);
+        }
+
+        public void Debug(string msg, params object[] args)
+        {
+            if (logHandler != null)
+                logHandler(LogDebug, msg, args);
+        }
+
+        public void Info(string msg, params object[] args)
+        {
+            if (logHandler != null)
+                logHandler(LogInfo, msg, args);
+        }
+   
+        public void Verbose(string msg, params object[] args)
+        {
+            if (logHandler != null)
+                logHandler(LogVerbose, msg, args);
+        }
+    }
+}

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -88,7 +88,7 @@
     <Compile Include="Http\IWebRequest.cs" />
     <Compile Include="Http\Result.cs" />
     <Compile Include="Http\ReynaWebRequest.cs" />
-    <Compile Include="Logging\ILoggerInterface.cs" />
+    <Compile Include="Logging\ILogDelegate.cs" />
     <Compile Include="NativeMethods\NativeMethods.cs" />
     <Compile Include="Network\INetwork.cs" />
     <Compile Include="Network\Network.cs" />

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -31,6 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
@@ -124,6 +125,8 @@
     <Compile Include="Threading\ThreadWorker.cs" />
     <Compile Include="UnityHelper.cs" />
     <Compile Include="Utilities\Constants.cs" />
+    <Compile Include="Logging\IReynaLogger.cs" />
+    <Compile Include="Logging\ReynaLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -31,7 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
@@ -89,6 +88,7 @@
     <Compile Include="Http\IWebRequest.cs" />
     <Compile Include="Http\Result.cs" />
     <Compile Include="Http\ReynaWebRequest.cs" />
+    <Compile Include="Logging\ILoggerInterface.cs" />
     <Compile Include="NativeMethods\NativeMethods.cs" />
     <Compile Include="Network\INetwork.cs" />
     <Compile Include="Network\Network.cs" />

--- a/src/reyna/Reyna/Services/ForwardService.cs
+++ b/src/reyna/Reyna/Services/ForwardService.cs
@@ -1,4 +1,5 @@
-﻿namespace Reyna
+﻿
+namespace Reyna
 {
     using System;
     using System.Threading;
@@ -10,10 +11,12 @@
         internal int SleepMilliseconds { get; set; }
         internal IHttpClient HttpClient { get; set; }
         internal INetworkStateService NetworkState { get; set; }
+        internal IReynaLogger Logger { get; set; }
 
-        public ForwardService(IAutoResetEventAdapter waitHandle)
+        public ForwardService(IAutoResetEventAdapter waitHandle, IReynaLogger logger)
             : base(waitHandle, true)
         {
+            Logger = logger;
         }
         
         protected override void ThreadStart()
@@ -28,7 +31,7 @@
         {
             this.WaitHandle.WaitOne();
             IMessage message = null;
-
+            Logger.Info("Reyna.ForwardService DoWork enter");
             while (!this.Terminate && (message = this.SourceStore.Get()) != null)
             {
                 var result = this.HttpClient.Post(message);
@@ -48,10 +51,13 @@
             }
 
             this.WaitHandle.Reset();
+            Logger.Info("Reyna.ForwardService DoWork exit");
         }
 
         internal void OnNetworkConnected(object sender, EventArgs e)
         {
+            Logger.Info("Reyna.ForwardService OnNetworkConnected");
+           
             if (this.Terminate)
             {
                 return;
@@ -63,6 +69,8 @@
         public void Initialize(IRepository sourceStore, IHttpClient httpClient, INetworkStateService networkState, 
             int temporaryErrorMilliseconds, int sleepMilliseconds)
         {
+            Logger.Info("Reyna.ForwardService Initialize enter");
+         
             if (httpClient == null)
             {
                 throw new ArgumentNullException("httpClient");
@@ -82,6 +90,8 @@
             this.NetworkState.NetworkConnected += this.OnNetworkConnected;
 
             base.Initialize(sourceStore);
+
+            Logger.Info("Reyna.ForwardService Initialize exit");
         }
     }
 }

--- a/src/reyna/Reyna/Services/IReyna.cs
+++ b/src/reyna/Reyna/Services/IReyna.cs
@@ -1,12 +1,9 @@
 ﻿
-
-using System;
-
 namespace Reyna.Interfaces
 {
     public interface IReyna : IService
     {
         void Put(IMessage message);
-        void EnableLogging(ILoggerInterface llog);
+        void EnableLogging(ILogDelegate llog);
     }
 }

--- a/src/reyna/Reyna/Services/IReyna.cs
+++ b/src/reyna/Reyna/Services/IReyna.cs
@@ -7,6 +7,6 @@ namespace Reyna.Interfaces
     public interface IReyna : IService
     {
         void Put(IMessage message);
-        void EnableLogging(ReynaLogger.LogHandler llog);
+        void EnableLogging(ILoggerInterface llog);
     }
 }

--- a/src/reyna/Reyna/Services/IReyna.cs
+++ b/src/reyna/Reyna/Services/IReyna.cs
@@ -1,7 +1,12 @@
-﻿namespace Reyna.Interfaces
+﻿
+
+using System;
+
+namespace Reyna.Interfaces
 {
     public interface IReyna : IService
     {
         void Put(IMessage message);
+        void EnableLogging(ReynaLogger.LogHandler llog);
     }
 }

--- a/src/reyna/Reyna/Services/ReynaService.cs
+++ b/src/reyna/Reyna/Services/ReynaService.cs
@@ -146,10 +146,9 @@ namespace Reyna
             this.VolatileStore.Add(message);
         }
 
-        public void EnableLogging(ReynaLogger.LogHandler logger)
+        public void EnableLogging(ILoggerInterface loggerAdapter)
         {
-           (Logger as ReynaLogger).Initialise(logger);
-           
+            Logger.Initialise(loggerAdapter);   
             Logger.Info("ReynaService.EnableLogging");
         }
 

--- a/src/reyna/Reyna/Services/ReynaService.cs
+++ b/src/reyna/Reyna/Services/ReynaService.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.Practices.Unity;
 
 namespace Reyna
 {
-    using Microsoft.Practices.Unity;
-    using Reyna.Interfaces;
+    using Interfaces;
 
     public sealed class ReynaService : IReyna
     {
@@ -146,9 +144,9 @@ namespace Reyna
             this.VolatileStore.Add(message);
         }
 
-        public void EnableLogging(ILoggerInterface loggerAdapter)
+        public void EnableLogging(ILogDelegate logDelegate)
         {
-            Logger.Initialise(loggerAdapter);   
+            Logger.Initialise(logDelegate);   
             Logger.Info("ReynaService.EnableLogging");
         }
 

--- a/src/reyna/Reyna/Services/ReynaService.cs
+++ b/src/reyna/Reyna/Services/ReynaService.cs
@@ -1,4 +1,7 @@
-﻿namespace Reyna
+﻿using System;
+using System.Collections.Generic;
+
+namespace Reyna
 {
     using Microsoft.Practices.Unity;
     using Reyna.Interfaces;
@@ -15,6 +18,8 @@
         internal IStoreService StoreService { get; set; }
         internal IForwardService ForwardService { get; set; }
         internal INetworkStateService NetworkStateService { get; set; }
+        internal IReynaLogger Logger { get; set; }
+        
         internal byte[] Password { get; set; }
 
         public ReynaService() : this(null)
@@ -34,7 +39,9 @@
             this.NetworkStateService = container.Resolve<INetworkStateService>();
             this.StoreService = container.Resolve<IStoreService>();
             this.ForwardService = container.Resolve<IForwardService>();
-            this.EncryptionChecker = container.Resolve<IEncryptionChecker>();   
+            this.EncryptionChecker = container.Resolve<IEncryptionChecker>();
+
+            this.Logger = container.Resolve<IReynaLogger>();
 
             this.StoreService.Initialize(this.VolatileStore, this.PersistentStore);
             this.ForwardService.Initialize(this.PersistentStore, this.HttpClient, this.NetworkStateService, this.Preferences.ForwardServiceTemporaryErrorBackout, this.Preferences.ForwardServiceMessageBackout);
@@ -106,6 +113,8 @@
 
         public void Start()
         {
+            Logger.Info("Reyna.ReynaService Start enter");  
+          
             if (this.Password != null && this.Password.Length > 0)
             {
                 if (!this.EncryptionChecker.DbEncrypted())
@@ -117,18 +126,31 @@
             this.StoreService.Start();
             this.ForwardService.Start();
             this.NetworkStateService.Start();
+
+            Logger.Info("Reyna.ReynaService Start exit");   
         }
 
         public void Stop()
         {
+            Logger.Info("Reyna.ReynaService Stop enter");  
+
             this.NetworkStateService.Stop();
             this.ForwardService.Stop();
             this.StoreService.Stop();
+            
+            Logger.Info("Reyna.ReynaService Stop exit");  
         }
 
         public void Put(IMessage message)
         {
             this.VolatileStore.Add(message);
+        }
+
+        public void EnableLogging(ReynaLogger.LogHandler logger)
+        {
+           (Logger as ReynaLogger).Initialise(logger);
+           
+            Logger.Info("ReynaService.EnableLogging");
         }
 
         public void Dispose()

--- a/src/reyna/Reyna/UnityHelper.cs
+++ b/src/reyna/Reyna/UnityHelper.cs
@@ -1,4 +1,5 @@
-﻿namespace Reyna
+﻿
+namespace Reyna
 {
     using Microsoft.Practices.Unity;
     using Reyna.Interfaces;
@@ -31,6 +32,8 @@
             container.RegisterType<IConnectionInfo, ConnectionInfo>();
             container.RegisterType<IBlackoutTime, BlackoutTime>();
             container.RegisterType<IWebRequest, ReynaWebRequest>();
+
+            container.RegisterInstance<IReynaLogger>(new ReynaLogger());
 
             return container;
         }


### PR DESCRIPTION
Add logging to Reyna without any third party dependencies. Uses a delegate exposed through an interface to call back into the Logger object in ElemezServiceHost.
1. Create ILogDelegate with Log method signature (logLevel, logMessage, array of params)
2. Add EnableLogging(ILogDelegate) method in IReyna to allow the calling application to pass in a LoggerAdapter delegate.
3. Add ReynaLogger class for Logger API support in Reyna. Simple to use just call Logger.Error, Info etc after Initialisation.
4. Register a singleton instance of ReynaLogger in UnityHelper and expose IReynaLogger in various Reyna classes.
5. Add useful Log statements.
6. Make relevant changes to ElemezServiceHost in order to enable logging in Reyna which is part of another pull request in the x86 branch.
