### PR TITLE
Restrict data upload

### DIFF
--- a/src/reyna/Reyna.Facts/Connection/GivenAConnectionInfo.cs
+++ b/src/reyna/Reyna.Facts/Connection/GivenAConnectionInfo.cs
@@ -10,7 +10,7 @@ namespace Reyna.Facts
         public GivenAConnectionInfo()
         {
             _mockConnectionCost = new Mock<IConnectionCost>();
-            _mockNetworkInterface = new Mock<INetworkInterfaceWrapper>();
+            _mockNetworkInterface = new Mock<INetworkInterfaceWrapperFactory>();
 
             _mockMobileNetworkInterface = new Mock<INetworkInterfaceWrapper>();
             _mockMobileNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wwanpp);
@@ -26,7 +26,7 @@ namespace Reyna.Facts
         }
 
         private readonly Mock<IConnectionCost> _mockConnectionCost;
-        private readonly Mock<INetworkInterfaceWrapper> _mockNetworkInterface;
+        private readonly Mock<INetworkInterfaceWrapperFactory> _mockNetworkInterface;
         private readonly Mock<INetworkInterfaceWrapper> _mockWirelessNetworkInterface;
         private readonly Mock<INetworkInterfaceWrapper> _mockMobileNetworkInterface;
 

--- a/src/reyna/Reyna.Facts/Connection/GivenAConnectionInfo.cs
+++ b/src/reyna/Reyna.Facts/Connection/GivenAConnectionInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.NetworkInformation;
+﻿using System;
+using System.Net.NetworkInformation;
 using Moq;
 using Xunit;
 
@@ -11,21 +12,23 @@ namespace Reyna.Facts
             _mockConnectionCost = new Mock<IConnectionCost>();
             _mockNetworkInterface = new Mock<INetworkInterfaceWrapper>();
 
-            var mockMobileNetworkInterface = new Mock<INetworkInterfaceWrapper>();
-            mockMobileNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wwanpp);
-            mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Down);
+            _mockMobileNetworkInterface = new Mock<INetworkInterfaceWrapper>();
+            _mockMobileNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wwanpp);
+            _mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Down);
 
-            var mockWirelessNetworkInterface = new Mock<INetworkInterfaceWrapper>();
-            mockWirelessNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wireless80211);
-            mockWirelessNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Up);
+            _mockWirelessNetworkInterface = new Mock<INetworkInterfaceWrapper>();
+            _mockWirelessNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wireless80211);
+            _mockWirelessNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Down);
 
-            _mockNetworkInterface.Setup(nc => nc.GetAllNetworkInterfaces()).Returns(new[] { mockWirelessNetworkInterface.Object, mockMobileNetworkInterface.Object });
+            _mockNetworkInterface.Setup(nc => nc.GetAllNetworkInterfaces()).Returns(new[] { _mockWirelessNetworkInterface.Object, _mockMobileNetworkInterface.Object });
 
             ConnectionInfo = new ConnectionInfo(_mockConnectionCost.Object, _mockNetworkInterface.Object);
         }
 
         private readonly Mock<IConnectionCost> _mockConnectionCost;
         private readonly Mock<INetworkInterfaceWrapper> _mockNetworkInterface;
+        private readonly Mock<INetworkInterfaceWrapper> _mockWirelessNetworkInterface;
+        private readonly Mock<INetworkInterfaceWrapper> _mockMobileNetworkInterface;
 
         private ConnectionInfo ConnectionInfo { get; set; }
 
@@ -35,28 +38,88 @@ namespace Reyna.Facts
             Assert.NotNull(ConnectionInfo);
         }
 
-        [Fact]
-        public void WhenGettingConnectedShouldReturnExpected()
+        [Theory]
+        [InlineData(true, OperationalStatus.Up)]
+        [InlineData(false, OperationalStatus.Down)]
+        public void WhenGettingConnectedShouldReturnExpected(bool expected, OperationalStatus status)
         {
-            //TODO
+            _mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(status);
+
+            Assert.Equal(expected, ConnectionInfo.Connected);
+        }
+
+        [Theory]
+        [InlineData(true, OperationalStatus.Up)]
+        [InlineData(false, OperationalStatus.Down)]
+        public void WhenGettingMobileShouldReturnExpected(bool expected, OperationalStatus status)
+        {
+            _mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(status);
+
+            Assert.Equal(expected, ConnectionInfo.Mobile);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WhenGettingRoamingShouldReturnExpected(bool expected)
+        {
+            _mockConnectionCost.Setup(ni => ni.Roaming).Returns(expected);
+
+            Assert.Equal(expected, ConnectionInfo.Roaming);
+        }
+
+        [Theory]
+        [InlineData(true, OperationalStatus.Up)]
+        [InlineData(false, OperationalStatus.Down)]
+        public void WhenGettingWifiShouldReturnExpected(bool expected, OperationalStatus status)
+        {
+            _mockWirelessNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(status);
+
+            Assert.Equal(expected, ConnectionInfo.Wifi);
+        }
+
+        [Theory]
+        [InlineData(NetworkInterfaceType.Wman)]
+        [InlineData(NetworkInterfaceType.Wwanpp)]
+        [InlineData(NetworkInterfaceType.Wwanpp2)]
+        public void WhenGettingMobileShouldWorkForEachTypeOfMobileNetworkInterface(NetworkInterfaceType type)
+        {
+            _mockMobileNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(type);
+            _mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Up);
+
+            Assert.True(ConnectionInfo.Mobile);
         }
 
         [Fact]
-        public void WhenGettingMobileShouldReturnExpected()
+        public void WhenGettingConnectedAndThrowsShouldCatchAndReturnFalse()
         {
-            //TODO
+            _mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Throws(new Exception());
+
+            Assert.False(ConnectionInfo.Connected);
         }
 
         [Fact]
-        public void WhenGettingRoamingShouldReturnExpected()
+        public void WhenGettingMobileAndThrowsShouldCatchAndReturnFalse()
         {
-            //TODO
+            _mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Throws(new Exception());
+            
+            Assert.False(ConnectionInfo.Mobile);
         }
 
         [Fact]
-        public void WhenGettingWifiShouldReturnExpected()
+        public void WhenGettingRoamingAndThrowsShouldCatchAndReturnFalse()
         {
-            //TODO
+            _mockConnectionCost.Setup(ni => ni.Roaming).Throws(new Exception());
+
+            Assert.False(ConnectionInfo.Roaming);
+        }
+
+        [Fact]
+        public void WhenGettingWifiAndThrowsShouldCatchAndReturnFalse()
+        {
+            _mockWirelessNetworkInterface.Setup(ni => ni.OperationalStatus).Throws(new Exception());
+
+            Assert.False(ConnectionInfo.Wifi);
         }
     }
 }

--- a/src/reyna/Reyna.Facts/Connection/GivenAConnectionInfo.cs
+++ b/src/reyna/Reyna.Facts/Connection/GivenAConnectionInfo.cs
@@ -1,262 +1,62 @@
-﻿namespace Reyna.Facts
-{
-    using Moq;
-    using Xunit;
-    using Xunit.Extensions;
+﻿using System.Net.NetworkInformation;
+using Moq;
+using Xunit;
 
+namespace Reyna.Facts
+{
     public class GivenAConnectionInfo
     {
-        //public GivenAConnectionInfo()
-        //{
-        //    this.ConnectionInfo = new ConnectionInfo();
-        //    this.ConnectionInfoMock = new Mock<IConnectionInfo>();
-        //    this.Registry = new Mock<IRegistry>();
-        //    this.ConnectionInfo.Registry = this.Registry.Object;
-        //}
+        public GivenAConnectionInfo()
+        {
+            _mockConnectionCost = new Mock<IConnectionCost>();
+            _mockNetworkInterface = new Mock<INetworkInterfaceWrapper>();
 
-        //private Mock<IConnectionInfo> ConnectionInfoMock { get; set; }
+            var mockMobileNetworkInterface = new Mock<INetworkInterfaceWrapper>();
+            mockMobileNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wwanpp);
+            mockMobileNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Down);
 
-        //private Mock<IRegistry> Registry { get; set; }
+            var mockWirelessNetworkInterface = new Mock<INetworkInterfaceWrapper>();
+            mockWirelessNetworkInterface.Setup(ni => ni.NetworkInterfaceType).Returns(NetworkInterfaceType.Wireless80211);
+            mockWirelessNetworkInterface.Setup(ni => ni.OperationalStatus).Returns(OperationalStatus.Up);
 
-        //private ConnectionInfo ConnectionInfo { get; set; }
+            _mockNetworkInterface.Setup(nc => nc.GetAllNetworkInterfaces()).Returns(new[] { mockWirelessNetworkInterface.Object, mockMobileNetworkInterface.Object });
 
-        //[Fact]
-        //public void Construction()
-        //{
-        //    this.ConnectionInfo = new ConnectionInfo();
-        //    Assert.NotNull(this.ConnectionInfo);
-        //    Assert.NotNull(this.ConnectionInfo.Registry);
-        //}
+            ConnectionInfo = new ConnectionInfo(_mockConnectionCost.Object, _mockNetworkInterface.Object);
+        }
 
-        //[Fact]
-        //public void WhenNetworkInterfaceWithIpExistsShouldReturnTrueForHasConnection()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(42);
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
+        private readonly Mock<IConnectionCost> _mockConnectionCost;
+        private readonly Mock<INetworkInterfaceWrapper> _mockNetworkInterface;
 
-        //    Assert.True(this.ConnectionInfo.Connected);
-        //}
+        private ConnectionInfo ConnectionInfo { get; set; }
 
-        //[Fact]
-        //public void WhenNetworkInterfaceWithIpExistsShouldReturnFalseForHasConnection()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(0);
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
+        [Fact]
+        public void Construction()
+        {
+            Assert.NotNull(ConnectionInfo);
+        }
 
-        //    Assert.False(this.ConnectionInfo.Connected);
-        //}
+        [Fact]
+        public void WhenGettingConnectedShouldReturnExpected()
+        {
+            //TODO
+        }
 
-        //[Fact]
-        //public void WhenCallingMobileAndOnlyWifiAvailableShouldReturnFalse()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(42);
-        //    networkInterface.Name = "wifi";
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
+        [Fact]
+        public void WhenGettingMobileShouldReturnExpected()
+        {
+            //TODO
+        }
 
-        //    Assert.False(this.ConnectionInfo.Mobile);
-        //}
+        [Fact]
+        public void WhenGettingRoamingShouldReturnExpected()
+        {
+            //TODO
+        }
 
-        //[Fact]
-        //public void WhenCallingConnectedAndExceptionShouldReturnFalse()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.False(this.ConnectionInfo.Connected);
-        //}
-
-        //[Fact]
-        //public void WhenCallingMobileAndOnlyGPRSAvailableShouldReturnTrue()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(42);
-        //    networkInterface.Name = "cellular line";
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.True(this.ConnectionInfo.Mobile);
-        //}
-
-        //[Fact]
-        //public void WhenCallingMobileAndOnlyGPRSAvailableButNotConnectedShouldReturnFalse()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(0);
-        //    networkInterface.Name = "cellular line";
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.False(this.ConnectionInfo.Mobile);
-        //}
-
-        //[Fact]
-        //public void WhenCallingMobileAndGPRSAndWifiConnectedShouldReturnFalse()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(43);
-        //    networkInterface.Name = "cellular line";
-
-        //    var wifi = new NetworkInterface();
-        //    wifi.CurrentIpAddress = new System.Net.IPAddress(43);
-        //    wifi.Name = "wifi";
-
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface, wifi };
-
-        //    Assert.False(this.ConnectionInfo.Mobile);
-        //}
-
-        //[Fact]
-        //public void WhenCallingMobileAndGPRSIsConnectedAndWifiNotConnectedShouldReturnTrue()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.CurrentIpAddress = new System.Net.IPAddress(43);
-        //    networkInterface.Name = "cellular line";
-
-        //    var wifi = new NetworkInterface();
-        //    wifi.CurrentIpAddress = new System.Net.IPAddress(0);
-        //    wifi.Name = "wifi";
-
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface, wifi };
-
-        //    Assert.True(this.ConnectionInfo.Mobile);
-        //}
-
-        //[Fact]
-        //public void WhenCallingMobileAndThrowsShouldReturnFalse()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.Name = "cellular line";
-
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.False(this.ConnectionInfo.Mobile);
-        //}
-
-        //[Fact]
-        //public void WhenCallingRoamingAndDeviceNoSupportingPhone()
-        //{
-        //    this.Registry.Setup(r => r.GetDWord(Microsoft.Win32.Registry.LocalMachine, "System\\State\\Phone", "Status", 0))
-        //        .Returns(0);
-
-        //    Assert.False(this.ConnectionInfo.Roaming);
-        //    this.Registry.Verify(r => r.GetDWord(Microsoft.Win32.Registry.LocalMachine, "System\\State\\Phone", "Status", 0), Times.Once());
-        //}
-
-        //[Fact]
-        //public void WhenCallingRoamingAndDeviceNotRoamingShouldReturnFalse()
-        //{
-        //    this.Registry.Setup(r => r.GetDWord(Microsoft.Win32.Registry.LocalMachine, "System\\State\\Phone", "Status", 0))
-        //        .Returns(0x32);
-
-        //    Assert.False(this.ConnectionInfo.Roaming);
-
-        //    this.Registry.Verify(r => r.GetDWord(Microsoft.Win32.Registry.LocalMachine, "System\\State\\Phone", "Status", 0), Times.Once());
-        //}
-
-        //[Fact]
-        //public void WhenCallingRoamingAndDeviceIsRoamingShouldReturnTrue()
-        //{
-        //    this.Registry.Setup(r => r.GetDWord(Microsoft.Win32.Registry.LocalMachine, "System\\State\\Phone", "Status", 0))
-        //        .Returns(0x32 | 0x200);
-
-        //    Assert.True(this.ConnectionInfo.Roaming);
-        //}
-
-        //[Fact]
-        //public void WhenCallingWifiAndWirelessZeroConfigNetworkInterfaceExistsShouldReturnTrue()
-        //{
-        //    var wirelessInterface = new WirelessZeroConfigNetworkInterface();
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { wirelessInterface };
-
-        //    Assert.True(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Fact]
-        //public void WhenCallingWifiAndWirelessNetworkInterfaceExistsShouldReturnTrue()
-        //{
-        //    var wirelessInterface = new WirelessNetworkInterface();
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { wirelessInterface };
-
-        //    Assert.True(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Theory]
-        //[InlineData(10000000)]
-        //[InlineData(100000000)]
-        //public void WhenCallingWifiAndLanNetworkInterfaceExistsShouldReturnFalse(int speed)
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.Speed = speed;
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.False(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Theory]
-        //[InlineData("USB Cable")]
-        //[InlineData("usb cable")]
-        //public void WhenCallingWifiAndActiveSyncNetworkInterfaceExistsShouldReturnFalse(string name)
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.Name = name;
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.False(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Theory]
-        //[InlineData("Cellular Line")]
-        //[InlineData("cellular line")]
-        //public void WhenCallingWifiAndGPRSNetworkInterfaceExistsShouldReturnFalse(string name)
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.Name = name;
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface };
-
-        //    Assert.False(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Fact]
-        //public void WhenCallingWifiAndMoreThanOneNetworkInterfaceExistsAndFirstOneIsUSBSkipItAndUseFirstWireless()
-        //{
-        //    var networkInterface = new NetworkInterface();
-        //    networkInterface.Name = "USB Cable";
-        //    var wirelessInterface = new WirelessNetworkInterface();
-
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { networkInterface, wirelessInterface };
-
-        //    Assert.True(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Fact]
-        //public void WhenCallingWifiAndMoreThanOneNetworkInterfaceExistsAndNoneIsWirelessNetworkInterface()
-        //{
-        //    var usbNetworkInterface = new NetworkInterface();
-        //    usbNetworkInterface.Name = "USB Cable";
-
-        //    var lanNetworkInterface = new NetworkInterface();
-        //    lanNetworkInterface.Speed = 10000000;
-
-        //    var wirelessInterface = new NetworkInterface();
-        //    wirelessInterface.Name = "WIRELESS";
-
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { usbNetworkInterface, lanNetworkInterface, wirelessInterface };
-
-        //    Assert.True(this.ConnectionInfo.Wifi);
-        //}
-
-        //[Fact]
-        //public void WhenCallingWifiAndNotUsingWifiShouldReturnFalse()
-        //{
-        //    var usbNetworkInterface = new NetworkInterface();
-        //    usbNetworkInterface.Name = "USB Cable";
-
-        //    var lanNetworkInterface = new NetworkInterface();
-        //    lanNetworkInterface.Speed = 10000000;
-
-        //    NetworkInterface.NetworkInterfaces = new INetworkInterface[] { usbNetworkInterface, lanNetworkInterface };
-        //    Assert.False(this.ConnectionInfo.Wifi);
-        //}
+        [Fact]
+        public void WhenGettingWifiShouldReturnExpected()
+        {
+            //TODO
+        }
     }
 }

--- a/src/reyna/Reyna.Facts/Connection/GivenAConnectionManager.cs
+++ b/src/reyna/Reyna.Facts/Connection/GivenAConnectionManager.cs
@@ -28,7 +28,7 @@ namespace Reyna.Facts.Connection
 
             this.connectionInfo.SetupGet(c => c.Connected).Returns(true);
             this.preferences.SetupGet(p => p.OnChargeBlackout).Returns(false);
-            this.powerManager.Setup(p => p.IsBatteryCharging()).Returns(false);
+            this.powerManager.Setup(p => p.IsPowerLineConnected()).Returns(false);
             this.preferences.SetupGet(p => p.OffChargeBlackout).Returns(false);
             this.preferences.SetupGet(p => p.RoamingBlackout).Returns(false);
             this.blackoutTime.Setup(b => b.CanSendAtTime(It.IsAny<DateTime>(), It.IsAny<String>())).Returns(true);
@@ -69,7 +69,7 @@ namespace Reyna.Facts.Connection
         public void whenCallingCanSendAndIsOnChargeBlackoutAndBatterIsChargingShouldReturnBlackout()
         {
             this.preferences.SetupGet(p => p.OnChargeBlackout).Returns(true);
-            this.powerManager.Setup(p => p.IsBatteryCharging()).Returns(true);
+            this.powerManager.Setup(p => p.IsPowerLineConnected()).Returns(true);
 
             var result = this.connectionManager.CanSend;
 
@@ -80,7 +80,7 @@ namespace Reyna.Facts.Connection
         public void whenCallingCanSendAndIsOffChargeBlackoutAndNotChargingShouldReturnBlackout()
         {
             this.preferences.SetupGet(p => p.OffChargeBlackout).Returns(true);
-            this.powerManager.Setup(p => p.IsBatteryCharging()).Returns(false);
+            this.powerManager.Setup(p => p.IsPowerLineConnected()).Returns(false);
 
             var result = this.connectionManager.CanSend;
 

--- a/src/reyna/Reyna.Facts/GivenAUnityHelper.cs
+++ b/src/reyna/Reyna.Facts/GivenAUnityHelper.cs
@@ -42,8 +42,13 @@ namespace Reyna.Facts
             Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IBlackoutTime) && r.MappedToType == typeof(BlackoutTime)));
             Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IWebRequest) && r.MappedToType == typeof(ReynaWebRequest)));
             Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IReynaLogger) && r.MappedToType == typeof(IReynaLogger)));
+            Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IRegistry) && r.MappedToType == typeof(Registry)));
+            Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IPowerStatusWrapper) && r.MappedToType == typeof(PowerStatusWrapper)));
+            Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(INetworkInterfaceWrapper) && r.MappedToType == typeof(NetworkInterfaceWrapper)));
+            Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(INetworkInterfaceWrapperFactory) && r.MappedToType == typeof(NetworkInterfaceWrapperFactory)));
+            Assert.NotNull(container.Registrations.FirstOrDefault(r => r.RegisteredType == typeof(IConnectionCost) && r.MappedToType == typeof(ConnectionCost)));
 
-            Assert.Equal(18, container.Registrations.Count()); // Always 1 ahead due to the default lifetime manager registration
+            Assert.Equal(23, container.Registrations.Count()); // Always 1 ahead due to the default lifetime manager registration
         }
     }
 }

--- a/src/reyna/Reyna.Facts/Power/GivenAPowerManager.cs
+++ b/src/reyna/Reyna.Facts/Power/GivenAPowerManager.cs
@@ -1,35 +1,40 @@
-﻿namespace Reyna.Facts
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using Reyna.Power;
-    using Xunit;
+﻿using System.Windows.Forms;
+using Moq;
+using Reyna.Power;
+using Xunit;
 
+namespace Reyna.Facts
+{
     public class GivenAPowerManager
     {
+        private readonly PowerManager _powerManager;
+        private readonly Mock<IPowerStatusWrapper> _mockPowerStatusWrapper;
+
+        public GivenAPowerManager()
+        {
+            _mockPowerStatusWrapper = new Mock<IPowerStatusWrapper>();
+            _powerManager = new PowerManager(_mockPowerStatusWrapper.Object);
+        }
+
         [Fact]
         public void WhenCallingIsBatteryChargingAndBatteryIsChargingShouldReturnTrue()
         {
-            NativeMethods.ACLineStatus = 1;
-            NativeMethods.SystemPowerStatusExResult = 1;
-            Assert.True(new PowerManager().IsBatteryCharging());
+            _mockPowerStatusWrapper.SetupGet(ps => ps.PowerLineStatus).Returns(PowerLineStatus.Online);
+            Assert.True(_powerManager.IsPowerLineConnected());
         }
 
         [Fact]
         public void WhenCallingIsBatteryChargingAndBatteryIsNotChargingShouldReturnFalse()
         {
-            NativeMethods.ACLineStatus = 0;
-            NativeMethods.SystemPowerStatusExResult = 1;
-            Assert.False(new PowerManager().IsBatteryCharging());
+            _mockPowerStatusWrapper.SetupGet(ps => ps.PowerLineStatus).Returns(PowerLineStatus.Offline);
+            Assert.False(_powerManager.IsPowerLineConnected());
         }
 
         [Fact]
         public void WhenCallingIsBatteryChargingAndBatteryFailedToGetPowerStatusShouldReturnFalse()
         {
-            NativeMethods.SystemPowerStatusExResult = 0;
-            Assert.False(new PowerManager().IsBatteryCharging());
+            _mockPowerStatusWrapper.SetupGet(ps => ps.PowerLineStatus).Returns(null);
+            Assert.False(_powerManager.IsPowerLineConnected());
         }
     }
 }

--- a/src/reyna/Reyna.Facts/Preferences/GivenAPreferences.cs
+++ b/src/reyna/Reyna.Facts/Preferences/GivenAPreferences.cs
@@ -1,13 +1,18 @@
-﻿namespace Reyna.Facts
+﻿using Moq;
+
+namespace Reyna.Facts
 {
     using Microsoft.Win32;
     using Xunit;
 
     public class GivenAPreferences
     {
+        private readonly Mock<IRegistry> _mockRegistry;
+
         public GivenAPreferences()
         {
-            this.Preferences = new Preferences();
+            _mockRegistry = new Mock<IRegistry>();
+            this.Preferences = new Preferences(_mockRegistry.Object);
         }
 
         public Preferences Preferences { get; set; }
@@ -15,46 +20,55 @@
         [Fact]
         public void WhenGettingCellularDataBlackoutAndThrowsShouldReturnNull()
         {
-            var registery = new Reyna.Registry();
-            registery.SetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:From", -3);
-            registery.SetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:To", -3);
+            _mockRegistry.Setup(
+                r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:From", It.IsAny<int>()))
+                .Returns(-3);
+            _mockRegistry.Setup(
+                r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:To", It.IsAny<int>()))
+                .Returns(-3);
             var timeRange = Preferences.CellularDataBlackout;
 
             Assert.Null(timeRange);
-            Registry.LocalMachine.DeleteSubKey(@"Software\Reyna", false);
         }
 
         [Fact]
         public void WhenSettingCellularDataBlackoutThenGetCellularDataBlackoutShouldReturnExpected()
         {
-            TimeRange range = new TimeRange(new Time(11, 00), new Time(12, 01));
-            this.Preferences.SetCellularDataBlackout(range);
-            
-            TimeRange timeRange = Preferences.CellularDataBlackout;
+            var range = new TimeRange(new Time(11, 00), new Time(12, 01));
+            _mockRegistry.Setup(
+                r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:From", It.IsAny<int>()))
+                .Returns(660);
+            _mockRegistry.Setup(
+                r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:To", It.IsAny<int>()))
+                .Returns(721);
 
-            Assert.Equal(range.From.MinuteOfDay, timeRange.From.MinuteOfDay);
-            Assert.Equal(range.To.MinuteOfDay, timeRange.To.MinuteOfDay);
+            var timeRange = Preferences.CellularDataBlackout;
+
+            Assert.Equal(timeRange.From.MinuteOfDay, range.From.MinuteOfDay);
+            Assert.Equal(timeRange.To.MinuteOfDay, range.To.MinuteOfDay);
         }
 
         [Fact]
-        public void WhenResetCellularDataBlackoutThenGetCellularDataBlackoutShouldReturnNull()
+        public void WhenResetCellularDataBlackoutShouldDeleteValuesFromRegistry()
         {
-            TimeRange range = new TimeRange(new Time(11, 00), new Time(12, 01));
-            this.Preferences.ResetCellularDataBlackout();
+            Preferences.ResetCellularDataBlackout();
 
-            TimeRange timeRange = Preferences.CellularDataBlackout;
-
-            Assert.Null(timeRange);
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:To"));
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:From"));
         }
 
         [Fact]
         public void WhenGetCellularDataBlackoutAndNotCorrectlySavedShouldReturnNull()
         {
-            TimeRange range = new TimeRange(new Time(11, 00), new Time(12, 01));
-            this.Preferences.SetCellularDataBlackout(range);
-            DeleteRegistryValue("DataBlackout:From");
+            var range = new TimeRange(new Time(11, 00), new Time(12, 01));
+            _mockRegistry.Setup(
+                r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:From", It.IsAny<int>()))
+                .Returns(-3);
+            _mockRegistry.Setup(
+                r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "DataBlackout:To", It.IsAny<int>()))
+                .Returns(721);
 
-            TimeRange timeRange = Preferences.CellularDataBlackout;
+            var timeRange = Preferences.CellularDataBlackout;
 
             Assert.Null(timeRange);
         }
@@ -62,21 +76,27 @@
         [Fact]
         public void WhenSettingWlanBlackoutRangeThenGetWlanBlackoutRangeShouldReturnExpected()
         {
-            this.Preferences.SetWlanBlackoutRange("00:00-00:01");
+            _mockRegistry.Setup(
+                r => r.GetString(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange", It.IsAny<string>()))
+                .Returns("00:00-00:01");
 
-            string actual = Preferences.WlanBlackoutRange;
+            var actual = Preferences.WlanBlackoutRange;
 
             Assert.Equal("00:00-00:01", actual);
             Assert.Equal("00:00-00:01", actual);
-
-            this.Preferences.SetWlanBlackoutRange("00:00-00:01,01:00-01:30");
+            
+            _mockRegistry.Setup(
+                r => r.GetString(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange", It.IsAny<string>()))
+                .Returns("00:00-00:01,01:00-01:30");
 
             actual = Preferences.WlanBlackoutRange;
 
             Assert.Equal("00:00-00:01,01:00-01:30", actual);
             Assert.Equal("00:00-00:01,01:00-01:30", actual);
-
-            this.Preferences.SetWlanBlackoutRange("00:00-00:01,01:00-01:30,11:23-18:20");
+            
+            _mockRegistry.Setup(
+                r => r.GetString(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange", It.IsAny<string>()))
+                .Returns("00:00-00:01,01:00-01:30,11:23-18:20");
 
             actual = Preferences.WlanBlackoutRange;
 
@@ -85,14 +105,11 @@
         }
 
         [Fact]
-        public void WhenResetWlanBlackoutRangeThenGetWlanBlackoutRangeShouldReturnNull()
+        public void WhenResetWlanBlackoutRangeShouldDeleteValuesFromRegistry()
         {
-            string range = "00:00-00:01";
             this.Preferences.ResetWlanBlackoutRange();
 
-            range = this.Preferences.WlanBlackoutRange;
-
-            Assert.Null(range);
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange"));
         }
 
         [Fact]
@@ -103,6 +120,7 @@
             var range = this.Preferences.WlanBlackoutRange;
 
             Assert.Null(range);
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange"));
         }
 
         [Fact]
@@ -113,13 +131,12 @@
             var range = this.Preferences.WwanBlackoutRange;
 
             Assert.Null(range);
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WwanBlackoutRange"));
         }
 
         [Fact]
         public void WhenNoWlanBlackoutRangeThenGetWlanBlackoutRangeShouldReturnNull()
         {
-            Microsoft.Win32.Registry.LocalMachine.DeleteSubKey(@"Software\Reyna", false);
-
             var range = this.Preferences.WlanBlackoutRange;
 
             Assert.Null(range);
@@ -128,8 +145,6 @@
         [Fact]
         public void WhenNoWwanBlackoutRangeThenGetWlanBlackoutRangeShouldReturnNull()
         {
-            Microsoft.Win32.Registry.LocalMachine.DeleteSubKey(@"Software\Reyna", false);
-
             var range = this.Preferences.WwanBlackoutRange;
 
             Assert.Null(range);
@@ -138,10 +153,7 @@
         [Fact]
         public void WhenGetWlanBlackoutRangeAndNotCorrectlySavedShouldReturnNull()
         {
-            this.Preferences.SetWlanBlackoutRange("00:00-00:01");
-            DeleteRegistryValue("WlanBlackoutRange");
-
-            string range = this.Preferences.WlanBlackoutRange;
+            var range = this.Preferences.WlanBlackoutRange;
 
             Assert.Null(range);
         }
@@ -149,164 +161,114 @@
         [Fact]
         public void WhenSettingWwanBlackoutRangeThenGetWwanBlackoutRangeShouldReturnExpected()
         {
-            this.Preferences.SetWwanBlackoutRange("00:00-00:01");
+            _mockRegistry.Setup(
+                r => r.GetString(Registry.LocalMachine, @"Software\Reyna", "WwanBlackoutRange", It.IsAny<string>()))
+                .Returns("00:00-00:01");
 
-            string actual = this.Preferences.WwanBlackoutRange;
+            var actual = this.Preferences.WwanBlackoutRange;
 
             Assert.Equal("00:00-00:01", actual);
             Assert.Equal("00:00-00:01", actual);
         }
 
         [Fact]
-        public void WhenResetWwanBlackoutRangeThenGetWwanBlackoutRangeShouldReturnNull()
+        public void WhenResetWwanBlackoutRangeShouldDeleteValuesFromRegistry()
         {
-            string range = "00:00-00:01";
             this.Preferences.ResetWwanBlackoutRange();
 
-            range = this.Preferences.WwanBlackoutRange;
-
-            Assert.Null(range);
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WwanBlackoutRange"));
         }
 
         [Fact]
         public void WhenGetWwanBlackoutRangeAndNotCorrectlySavedShouldReturnNull()
         {
-            this.Preferences.SetWwanBlackoutRange("00:00-00:01");
-            DeleteRegistryValue("WwanBlackoutRange");
-
-            string range = this.Preferences.WwanBlackoutRange;
+            var range = this.Preferences.WwanBlackoutRange;
 
             Assert.Null(range);
         }
 
         [Fact]
-        public void WhenSettingRoamingBlackoutThenGetRoamingBlackoutShouldReturnExpected()
+        public void WhenSettingRoamingBlackoutShouldSetValueInRegistry()
         {
             this.Preferences.SetRoamingBlackout(true);
-            bool roamingBlackout = this.Preferences.RoamingBlackout;
-
-            Assert.True(roamingBlackout);
-
-            this.Preferences.SetRoamingBlackout(false);
-            roamingBlackout = this.Preferences.RoamingBlackout;
-
-            Assert.False(roamingBlackout);
+            _mockRegistry.Verify(r => r.SetDWord(Registry.LocalMachine, @"Software\Reyna", "RoamingBlackout", 1));
         }
 
         [Fact]
-        public void WhenResetRoamingBlackoutThenGetRoamingBlackoutShouldReturnTrue()
+        public void WhenSettingOffChargeBlackoutShouldSetValueInRegistry()
         {
-            this.Preferences.SetRoamingBlackout(false);
-            this.Preferences.ResetRoamingBlackout();
-            bool roamingBlackout = this.Preferences.RoamingBlackout;
-
-            Assert.True(roamingBlackout);
+            this.Preferences.SetOffChargeBlackout(true);
+            _mockRegistry.Verify(r => r.SetDWord(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout", 1));
         }
 
         [Fact]
-        public void WhenGetRoamingBlackoutAndNotCorrectlySavedReturnTrue()
-        {
-            this.Preferences.SetRoamingBlackout(false);
-            DeleteRegistryValue("RoamingBlackout");
-            bool roamingBlackout = this.Preferences.RoamingBlackout;
-
-            Assert.True(roamingBlackout);
-        }
-
-        [Fact]
-        public void WhenGetRoamingBlackoutAndNeverSetRoamingBeforeShouldReturnFalse()
-        {
-            Microsoft.Win32.Registry.LocalMachine.DeleteSubKey(@"Software\Reyna", false);
-
-            var actual = this.Preferences.RoamingBlackout;
-
-            Assert.True(actual);
-        }
-
-        [Fact]
-        public void WhenGetOnChargeBlackoutAndNeverSetRoamingBeforeShouldReturnFalse()
-        {
-            Microsoft.Win32.Registry.LocalMachine.DeleteSubKey(@"Software\Reyna", false);
-
-            var actual = this.Preferences.OnChargeBlackout;
-
-            Assert.False(actual);
-        }
-
-        [Fact]
-        public void WhenGetOffChargeBlackoutAndNeverSetRoamingBeforeShouldReturnFalse()
-        {
-            Microsoft.Win32.Registry.LocalMachine.DeleteSubKey(@"Software\Reyna", false);
-
-            var actual = this.Preferences.OffChargeBlackout;
-
-            Assert.False(actual);
-        }
-
-        [Fact]
-        public void WhenSettingOnChargeBlackoutThenGetOnChargeBlackoutShouldReturnExpected()
+        public void WhenSettingOnChargeBlackoutShouldSetValueInRegistry()
         {
             this.Preferences.SetOnChargeBlackout(true);
-            bool chargingBlackout = this.Preferences.OnChargeBlackout;
-
-            Assert.True(chargingBlackout);
-
-            this.Preferences.SetOnChargeBlackout(false);
-            chargingBlackout = this.Preferences.OnChargeBlackout;
-
-            Assert.False(chargingBlackout);
+            _mockRegistry.Verify(r => r.SetDWord(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout", 1));
         }
 
         [Fact]
-        public void WhenResetOnChargeBlackoutThenGetOnChargeBlackoutShouldReturnFalse()
+        public void WhenGettingRoamingBlackoutShouldGetValueFromRegistry()
         {
-            this.Preferences.SetOnChargeBlackout(true);
+            _mockRegistry.Setup(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "RoamingBlackout", 1)).Returns(1);
+
+            var result = this.Preferences.RoamingBlackout;
+
+            _mockRegistry.Verify(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "RoamingBlackout", 1));
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void WhenGettingOffChargeBlackoutShouldGetValueFromRegistry()
+        {
+            _mockRegistry.Setup(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout", 0)).Returns(1);
+
+            var result = this.Preferences.OffChargeBlackout;
+
+            _mockRegistry.Verify(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout", 0));
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void WhenGettingOnChargeBlackoutShouldGetValueFromRegistry()
+        {
+            _mockRegistry.Setup(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout", 0)).Returns(1);
+
+            var result = this.Preferences.OnChargeBlackout;
+
+            _mockRegistry.Verify(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout", 0));
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void WhenResetOnChargeBlackoutShouldDeleteValuesFromRegistry()
+        {
             this.Preferences.ResetOnChargeBlackout();
-            bool chargingBlackout = this.Preferences.OnChargeBlackout;
 
-            Assert.False(chargingBlackout);
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout"));
         }
 
         [Fact]
         public void WhenGetOnChargeBlackoutAndNotCorrectlySavedReturnFalse()
         {
-            this.Preferences.SetOnChargeBlackout(true);
-            DeleteRegistryValue("OnChargeBlackout");
-            bool chargingBlackout = this.Preferences.OnChargeBlackout;
+            var chargingBlackout = this.Preferences.OnChargeBlackout;
 
             Assert.False(chargingBlackout);
         }
 
         [Fact]
-        public void WhenSettingOffChargeBlackoutThenGetOffChargeBlackoutShouldReturnExpected()
+        public void WhenResetOffChargeBlackoutShouldDeleteValuesFromRegistry()
         {
-            this.Preferences.SetOffChargeBlackout(true);
-            bool dischargingBlackout = this.Preferences.OffChargeBlackout;
-
-            Assert.True(dischargingBlackout);
-
-            this.Preferences.SetOffChargeBlackout(false);
-            dischargingBlackout = this.Preferences.OffChargeBlackout;
-
-            Assert.False(dischargingBlackout);
-        }
-
-        [Fact]
-        public void WhenResetOffChargeBlackoutThenGetOffChargeBlackoutShouldReturnFalse()
-        {
-            this.Preferences.SetOffChargeBlackout(true);
             this.Preferences.ResetOffChargeBlackout();
-            bool dischargingBlackout = this.Preferences.OffChargeBlackout;
-
-            Assert.False(dischargingBlackout);
+            
+            _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout"));
         }
 
         [Fact]
         public void WhenGetOffChargeBlackoutAndNotCorrectlySavedReturnFalse()
         {
-            this.Preferences.SetOffChargeBlackout(true);
-            DeleteRegistryValue("OffChargeBlackout");
-            bool dischargingBlackout = this.Preferences.OffChargeBlackout;
+            var dischargingBlackout = this.Preferences.OffChargeBlackout;
 
             Assert.False(dischargingBlackout);
         }
@@ -329,17 +291,6 @@
             Assert.False(Preferences.IsBlackoutRangeValid("00:00-02:30-15:42"));
             Assert.False(Preferences.IsBlackoutRangeValid("13:00 - 21:00"));
             Assert.False(Preferences.IsBlackoutRangeValid("1300-21:00"));
-        }
-
-        private static void DeleteRegistryValue(string keyName)
-        {
-            using (var key = Registry.LocalMachine.OpenSubKey(@"Software\Reyna", true))
-            {
-                if (key != null)
-                {
-                    key.DeleteValue(keyName);
-                }
-            }
         }
     }
 }

--- a/src/reyna/Reyna.Facts/Preferences/GivenAPreferences.cs
+++ b/src/reyna/Reyna.Facts/Preferences/GivenAPreferences.cs
@@ -12,7 +12,7 @@ namespace Reyna.Facts
         public GivenAPreferences()
         {
             _mockRegistry = new Mock<IRegistry>();
-            this.Preferences = new Preferences(_mockRegistry.Object);
+            Preferences = new Preferences(_mockRegistry.Object);
         }
 
         public Preferences Preferences { get; set; }
@@ -107,7 +107,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenResetWlanBlackoutRangeShouldDeleteValuesFromRegistry()
         {
-            this.Preferences.ResetWlanBlackoutRange();
+            Preferences.ResetWlanBlackoutRange();
 
             _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange"));
         }
@@ -115,9 +115,9 @@ namespace Reyna.Facts
         [Fact]
         public void WhenSettingWlanBlackoutRangeWithInvalidRangeShouldResetIt()
         {
-            this.Preferences.SetWlanBlackoutRange("00");
+            Preferences.SetWlanBlackoutRange("00");
 
-            var range = this.Preferences.WlanBlackoutRange;
+            var range = Preferences.WlanBlackoutRange;
 
             Assert.Null(range);
             _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WlanBlackoutRange"));
@@ -126,9 +126,9 @@ namespace Reyna.Facts
         [Fact]
         public void WhenSettingWwanBlackoutRangeWithInvalidRangeShouldResetIt()
         {
-            this.Preferences.SetWwanBlackoutRange("00");
+            Preferences.SetWwanBlackoutRange("00");
 
-            var range = this.Preferences.WwanBlackoutRange;
+            var range = Preferences.WwanBlackoutRange;
 
             Assert.Null(range);
             _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WwanBlackoutRange"));
@@ -137,7 +137,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenNoWlanBlackoutRangeThenGetWlanBlackoutRangeShouldReturnNull()
         {
-            var range = this.Preferences.WlanBlackoutRange;
+            var range = Preferences.WlanBlackoutRange;
 
             Assert.Null(range);
         }
@@ -145,7 +145,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenNoWwanBlackoutRangeThenGetWlanBlackoutRangeShouldReturnNull()
         {
-            var range = this.Preferences.WwanBlackoutRange;
+            var range = Preferences.WwanBlackoutRange;
 
             Assert.Null(range);
         }
@@ -153,7 +153,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenGetWlanBlackoutRangeAndNotCorrectlySavedShouldReturnNull()
         {
-            var range = this.Preferences.WlanBlackoutRange;
+            var range = Preferences.WlanBlackoutRange;
 
             Assert.Null(range);
         }
@@ -165,7 +165,7 @@ namespace Reyna.Facts
                 r => r.GetString(Registry.LocalMachine, @"Software\Reyna", "WwanBlackoutRange", It.IsAny<string>()))
                 .Returns("00:00-00:01");
 
-            var actual = this.Preferences.WwanBlackoutRange;
+            var actual = Preferences.WwanBlackoutRange;
 
             Assert.Equal("00:00-00:01", actual);
             Assert.Equal("00:00-00:01", actual);
@@ -174,7 +174,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenResetWwanBlackoutRangeShouldDeleteValuesFromRegistry()
         {
-            this.Preferences.ResetWwanBlackoutRange();
+            Preferences.ResetWwanBlackoutRange();
 
             _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "WwanBlackoutRange"));
         }
@@ -182,7 +182,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenGetWwanBlackoutRangeAndNotCorrectlySavedShouldReturnNull()
         {
-            var range = this.Preferences.WwanBlackoutRange;
+            var range = Preferences.WwanBlackoutRange;
 
             Assert.Null(range);
         }
@@ -190,21 +190,21 @@ namespace Reyna.Facts
         [Fact]
         public void WhenSettingRoamingBlackoutShouldSetValueInRegistry()
         {
-            this.Preferences.SetRoamingBlackout(true);
+            Preferences.SetRoamingBlackout(true);
             _mockRegistry.Verify(r => r.SetDWord(Registry.LocalMachine, @"Software\Reyna", "RoamingBlackout", 1));
         }
 
         [Fact]
         public void WhenSettingOffChargeBlackoutShouldSetValueInRegistry()
         {
-            this.Preferences.SetOffChargeBlackout(true);
+            Preferences.SetOffChargeBlackout(true);
             _mockRegistry.Verify(r => r.SetDWord(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout", 1));
         }
 
         [Fact]
         public void WhenSettingOnChargeBlackoutShouldSetValueInRegistry()
         {
-            this.Preferences.SetOnChargeBlackout(true);
+            Preferences.SetOnChargeBlackout(true);
             _mockRegistry.Verify(r => r.SetDWord(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout", 1));
         }
 
@@ -213,7 +213,7 @@ namespace Reyna.Facts
         {
             _mockRegistry.Setup(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "RoamingBlackout", 1)).Returns(1);
 
-            var result = this.Preferences.RoamingBlackout;
+            var result = Preferences.RoamingBlackout;
 
             _mockRegistry.Verify(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "RoamingBlackout", 1));
             Assert.True(result);
@@ -224,7 +224,7 @@ namespace Reyna.Facts
         {
             _mockRegistry.Setup(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout", 0)).Returns(1);
 
-            var result = this.Preferences.OffChargeBlackout;
+            var result = Preferences.OffChargeBlackout;
 
             _mockRegistry.Verify(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout", 0));
             Assert.True(result);
@@ -235,7 +235,7 @@ namespace Reyna.Facts
         {
             _mockRegistry.Setup(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout", 0)).Returns(1);
 
-            var result = this.Preferences.OnChargeBlackout;
+            var result = Preferences.OnChargeBlackout;
 
             _mockRegistry.Verify(r => r.GetDWord(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout", 0));
             Assert.True(result);
@@ -244,7 +244,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenResetOnChargeBlackoutShouldDeleteValuesFromRegistry()
         {
-            this.Preferences.ResetOnChargeBlackout();
+            Preferences.ResetOnChargeBlackout();
 
             _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "OnChargeBlackout"));
         }
@@ -252,7 +252,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenGetOnChargeBlackoutAndNotCorrectlySavedReturnFalse()
         {
-            var chargingBlackout = this.Preferences.OnChargeBlackout;
+            var chargingBlackout = Preferences.OnChargeBlackout;
 
             Assert.False(chargingBlackout);
         }
@@ -260,7 +260,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenResetOffChargeBlackoutShouldDeleteValuesFromRegistry()
         {
-            this.Preferences.ResetOffChargeBlackout();
+            Preferences.ResetOffChargeBlackout();
             
             _mockRegistry.Verify(r => r.DeleteValue(Registry.LocalMachine, @"Software\Reyna", "OffChargeBlackout"));
         }
@@ -268,7 +268,7 @@ namespace Reyna.Facts
         [Fact]
         public void WhenGetOffChargeBlackoutAndNotCorrectlySavedReturnFalse()
         {
-            var dischargingBlackout = this.Preferences.OffChargeBlackout;
+            var dischargingBlackout = Preferences.OffChargeBlackout;
 
             Assert.False(dischargingBlackout);
         }

--- a/src/reyna/Reyna.Facts/Reyna.Facts.csproj
+++ b/src/reyna/Reyna.Facts/Reyna.Facts.csproj
@@ -73,6 +73,7 @@
       <HintPath>..\packages\System.Data.SQLite.Linq.1.0.98.1\lib\net45\System.Data.SQLite.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -122,7 +123,9 @@
       <Name>Reyna</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/reyna/Reyna.Integration.Facts/Reyna.Integration.Facts.csproj
+++ b/src/reyna/Reyna.Integration.Facts/Reyna.Integration.Facts.csproj
@@ -100,6 +100,9 @@
       <Name>Reyna</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/reyna/Reyna/Connection/ConnectionCost.cs
+++ b/src/reyna/Reyna/Connection/ConnectionCost.cs
@@ -1,0 +1,16 @@
+﻿using Windows.Networking.Connectivity;
+
+namespace Reyna
+{
+    class ConnectionCost : IConnectionCost
+    {
+        public bool Roaming
+        {
+            get
+            {
+                ConnectionProfile internetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
+                return internetConnectionProfile.GetConnectionCost().Roaming;
+            }
+        }
+    }
+}

--- a/src/reyna/Reyna/Connection/ConnectionCost.cs
+++ b/src/reyna/Reyna/Connection/ConnectionCost.cs
@@ -2,7 +2,7 @@
 
 namespace Reyna
 {
-    class ConnectionCost : IConnectionCost
+    public class ConnectionCost : IConnectionCost
     {
         public bool Roaming
         {

--- a/src/reyna/Reyna/Connection/ConnectionInfo.cs
+++ b/src/reyna/Reyna/Connection/ConnectionInfo.cs
@@ -6,12 +6,12 @@
     public class ConnectionInfo : IConnectionInfo
     {
         private readonly IConnectionCost _connectionCost;
-        private readonly INetworkInterfaceWrapper _networkInterfaceWrapper;
+        private readonly INetworkInterfaceWrapperFactory _networkInterfaceWrapper;
 
-        public ConnectionInfo(IConnectionCost connectionCost = null, INetworkInterfaceWrapper networkInterfaceWrapper = null)
+        public ConnectionInfo(IConnectionCost connectionCost, INetworkInterfaceWrapperFactory networkInterfaceWrapperFactory)
         {
-            _connectionCost = connectionCost ?? new ConnectionCost();
-            _networkInterfaceWrapper = networkInterfaceWrapper ?? new NetworkInterfaceWrapper();
+            _connectionCost = connectionCost;
+            _networkInterfaceWrapper = networkInterfaceWrapperFactory;
         }
 
         public bool Connected

--- a/src/reyna/Reyna/Connection/ConnectionInfo.cs
+++ b/src/reyna/Reyna/Connection/ConnectionInfo.cs
@@ -22,16 +22,18 @@
                 {
                     foreach (var ni in _networkInterfaceWrapper.GetAllNetworkInterfaces())
                     {
-                        if (ni.OperationalStatus == OperationalStatus.Up && ni.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+                        if (ni.OperationalStatus == OperationalStatus.Up &&
+                            ni.NetworkInterfaceType != NetworkInterfaceType.Loopback &&
+                            ni.NetworkInterfaceType != NetworkInterfaceType.Tunnel)
                         {
                             return true;
                         }
                     }
                 }
                 catch (Exception)
-                { 
+                {
                 }
-                
+
                 return false;
             }
         }
@@ -54,7 +56,9 @@
                                 mobileNetworkConnected = true;
                             }
                         }
-                        else if (ni.NetworkInterfaceType != NetworkInterfaceType.Loopback && ni.OperationalStatus == OperationalStatus.Up)
+                        else if (ni.NetworkInterfaceType != NetworkInterfaceType.Loopback &&
+                                 ni.NetworkInterfaceType != NetworkInterfaceType.Tunnel &&
+                                 ni.OperationalStatus == OperationalStatus.Up)
                         {
                             otherNetworksConnected = true;
                         }

--- a/src/reyna/Reyna/Connection/ConnectionInfo.cs
+++ b/src/reyna/Reyna/Connection/ConnectionInfo.cs
@@ -8,10 +8,10 @@
         private readonly IConnectionCost _connectionCost;
         private readonly INetworkInterfaceWrapper _networkInterfaceWrapper;
 
-        public ConnectionInfo(IConnectionCost connectionCost, INetworkInterfaceWrapper networkInterfaceWrapper)
+        public ConnectionInfo(IConnectionCost connectionCost = null, INetworkInterfaceWrapper networkInterfaceWrapper = null)
         {
-            _connectionCost = connectionCost;
-            _networkInterfaceWrapper = networkInterfaceWrapper;
+            _connectionCost = connectionCost ?? new ConnectionCost();
+            _networkInterfaceWrapper = networkInterfaceWrapper ?? new NetworkInterfaceWrapper();
         }
 
         public bool Connected

--- a/src/reyna/Reyna/Connection/ConnectionManager.cs
+++ b/src/reyna/Reyna/Connection/ConnectionManager.cs
@@ -38,12 +38,12 @@
                     Preferences.SaveCellularDataAsWwanForBackwardsCompatibility();
                 }
 
-                if (this.Preferences.OnChargeBlackout && this.PowerManager.IsBatteryCharging())
+                if (this.Preferences.OnChargeBlackout && this.PowerManager.IsPowerLineConnected())
                 {
                     return Result.Blackout;
                 }
 
-                if (this.Preferences.OffChargeBlackout && !this.PowerManager.IsBatteryCharging())
+                if (this.Preferences.OffChargeBlackout && !this.PowerManager.IsPowerLineConnected())
                 {
                     return Result.Blackout;
                 }

--- a/src/reyna/Reyna/Connection/ConnectionManager.cs
+++ b/src/reyna/Reyna/Connection/ConnectionManager.cs
@@ -1,34 +1,30 @@
 ﻿namespace Reyna
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-    using Reyna.Interfaces;
-    using Reyna.Power;
+    using Interfaces;
 
     public class ConnectionManager : IConnectionManager
     {
-        internal IPreferences Preferences { get; set; }
+        private IPreferences Preferences { get; set; }
 
-        internal IPowerManager PowerManager { get; set; }
+        private IPowerManager PowerManager { get; set; }
 
-        internal IConnectionInfo ConnectionInfo { get; set; }
+        private IConnectionInfo ConnectionInfo { get; set; }
 
-        internal IBlackoutTime BlackoutTime  { get; set; }
+        private IBlackoutTime BlackoutTime  { get; set; }
 
         public ConnectionManager(IPreferences preferences, IPowerManager powerManager, IConnectionInfo connectionInfo, IBlackoutTime blackoutTime)
         {
-            this.Preferences = preferences;
-            this.PowerManager = powerManager;
-            this.ConnectionInfo = connectionInfo;
-            this.BlackoutTime = blackoutTime;
+            Preferences = preferences;
+            PowerManager = powerManager;
+            ConnectionInfo = connectionInfo;
+            BlackoutTime = blackoutTime;
         }
 
         public Result CanSend
         {
             get
             {
-                if (!this.ConnectionInfo.Connected)
+                if (!ConnectionInfo.Connected)
                 {
                     return Result.NotConnected;
                 }
@@ -38,27 +34,27 @@
                     Preferences.SaveCellularDataAsWwanForBackwardsCompatibility();
                 }
 
-                if (this.Preferences.OnChargeBlackout && this.PowerManager.IsPowerLineConnected())
+                if (Preferences.OnChargeBlackout && PowerManager.IsPowerLineConnected())
                 {
                     return Result.Blackout;
                 }
 
-                if (this.Preferences.OffChargeBlackout && !this.PowerManager.IsPowerLineConnected())
+                if (Preferences.OffChargeBlackout && !PowerManager.IsPowerLineConnected())
                 {
                     return Result.Blackout;
                 }
 
-                if (this.Preferences.RoamingBlackout && this.ConnectionInfo.Roaming)
+                if (Preferences.RoamingBlackout && ConnectionInfo.Roaming)
                 {
                     return Result.Blackout;
                 } 
 
-                if (!this.CanSendNow(this.BlackoutTime, this.Preferences.WlanBlackoutRange) && this.ConnectionInfo.Wifi)
+                if (!CanSendNow(BlackoutTime, Preferences.WlanBlackoutRange) && ConnectionInfo.Wifi)
                 {
                     return Result.Blackout;
                 }
 
-                if (!this.CanSendNow(this.BlackoutTime, this.Preferences.WwanBlackoutRange) && this.ConnectionInfo.Mobile)
+                if (!CanSendNow(BlackoutTime, Preferences.WwanBlackoutRange) && ConnectionInfo.Mobile)
                 {
                     return Result.Blackout;
                 }

--- a/src/reyna/Reyna/Connection/IConnectionCost.cs
+++ b/src/reyna/Reyna/Connection/IConnectionCost.cs
@@ -1,0 +1,7 @@
+namespace Reyna
+{
+    public interface IConnectionCost
+    {
+        bool Roaming { get; }
+    }
+}

--- a/src/reyna/Reyna/Http/HttpClient.cs
+++ b/src/reyna/Reyna/Http/HttpClient.cs
@@ -36,7 +36,7 @@ namespace Reyna
                 Result result = CanSend();
                 if (result != Result.Ok)
                 {
-                    Logger.Info("Reyna.HttpClient Post cannot send");
+                    Logger.Info("Reyna.HttpClient Post cannot send: {0}", result.ToString());
                     return result;
                 }
 
@@ -55,6 +55,8 @@ namespace Reyna
 
                     this.webRequest.AddHeader(key, value);
                 }
+
+                Logger.Info("Reyna.HttpClient Post can send: {0}", result.ToString());
 
                 return this.webRequest.Send(message.Body);
             }

--- a/src/reyna/Reyna/Network/INetworkInterfaceWrapper.cs
+++ b/src/reyna/Reyna/Network/INetworkInterfaceWrapper.cs
@@ -4,7 +4,6 @@ namespace Reyna
 {
     public interface INetworkInterfaceWrapper
     {
-        INetworkInterfaceWrapper[] GetAllNetworkInterfaces();
         NetworkInterfaceType NetworkInterfaceType { get; }
         OperationalStatus OperationalStatus { get; }
     }

--- a/src/reyna/Reyna/Network/INetworkInterfaceWrapper.cs
+++ b/src/reyna/Reyna/Network/INetworkInterfaceWrapper.cs
@@ -1,0 +1,11 @@
+using System.Net.NetworkInformation;
+
+namespace Reyna
+{
+    public interface INetworkInterfaceWrapper
+    {
+        INetworkInterfaceWrapper[] GetAllNetworkInterfaces();
+        NetworkInterfaceType NetworkInterfaceType { get; }
+        OperationalStatus OperationalStatus { get; }
+    }
+}

--- a/src/reyna/Reyna/Network/INetworkInterfaceWrapperFactory.cs
+++ b/src/reyna/Reyna/Network/INetworkInterfaceWrapperFactory.cs
@@ -1,0 +1,7 @@
+namespace Reyna
+{
+    public interface INetworkInterfaceWrapperFactory
+    {
+        INetworkInterfaceWrapper[] GetAllNetworkInterfaces();
+    }
+}

--- a/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
+++ b/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Net.NetworkInformation;
+﻿using System.Net.NetworkInformation;
 
 namespace Reyna
 {
@@ -10,13 +9,6 @@ namespace Reyna
         public NetworkInterfaceWrapper(NetworkInterface networkInterface = null)
         {
             _networkInterface = networkInterface;
-        }
-
-        public INetworkInterfaceWrapper[] GetAllNetworkInterfaces()
-        {
-            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
-
-            return interfaces.Select(networkInterface => new NetworkInterfaceWrapper(networkInterface)).Cast<INetworkInterfaceWrapper>().ToArray();
         }
 
         public NetworkInterfaceType NetworkInterfaceType

--- a/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
+++ b/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using System.Net.NetworkInformation;
+
+namespace Reyna
+{
+    public class NetworkInterfaceWrapper : INetworkInterfaceWrapper
+    {
+        private readonly NetworkInterface _networkInterface;
+
+        public NetworkInterfaceWrapper(NetworkInterface networkInterface)
+        {
+            _networkInterface = networkInterface;
+        }
+
+        public INetworkInterfaceWrapper[] GetAllNetworkInterfaces()
+        {
+            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
+
+            return interfaces.Select(networkInterface => new NetworkInterfaceWrapper(networkInterface)).Cast<INetworkInterfaceWrapper>().ToArray();
+        }
+
+        public NetworkInterfaceType NetworkInterfaceType
+        {
+            get { return _networkInterface.NetworkInterfaceType; }
+        }
+
+        public OperationalStatus OperationalStatus
+        {
+            get { return _networkInterface.OperationalStatus; }
+        }
+    }
+}

--- a/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
+++ b/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
@@ -21,12 +21,20 @@ namespace Reyna
 
         public NetworkInterfaceType NetworkInterfaceType
         {
-            get { return _networkInterface?.NetworkInterfaceType ?? NetworkInterfaceType.Unknown; }
+            get
+            {
+                if (_networkInterface == null) return NetworkInterfaceType.Unknown;
+                return _networkInterface.NetworkInterfaceType;
+            }
         }
 
         public OperationalStatus OperationalStatus
         {
-            get { return _networkInterface?.OperationalStatus ?? OperationalStatus.Unknown; }
+            get
+            {
+                if (_networkInterface == null) return OperationalStatus.Unknown;
+                return _networkInterface.OperationalStatus;
+            }
         }
     }
 }

--- a/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
+++ b/src/reyna/Reyna/Network/NetworkInterfaceWrapper.cs
@@ -7,7 +7,7 @@ namespace Reyna
     {
         private readonly NetworkInterface _networkInterface;
 
-        public NetworkInterfaceWrapper(NetworkInterface networkInterface)
+        public NetworkInterfaceWrapper(NetworkInterface networkInterface = null)
         {
             _networkInterface = networkInterface;
         }
@@ -21,12 +21,12 @@ namespace Reyna
 
         public NetworkInterfaceType NetworkInterfaceType
         {
-            get { return _networkInterface.NetworkInterfaceType; }
+            get { return _networkInterface?.NetworkInterfaceType ?? NetworkInterfaceType.Unknown; }
         }
 
         public OperationalStatus OperationalStatus
         {
-            get { return _networkInterface.OperationalStatus; }
+            get { return _networkInterface?.OperationalStatus ?? OperationalStatus.Unknown; }
         }
     }
 }

--- a/src/reyna/Reyna/Network/NetworkInterfaceWrapperFactory.cs
+++ b/src/reyna/Reyna/Network/NetworkInterfaceWrapperFactory.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using System.Net.NetworkInformation;
+
+namespace Reyna
+{
+    public class NetworkInterfaceWrapperFactory : INetworkInterfaceWrapperFactory
+    {
+        public INetworkInterfaceWrapper[] GetAllNetworkInterfaces()
+        {
+            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
+
+            return interfaces.Select(networkInterface => new NetworkInterfaceWrapper(networkInterface)).Cast<INetworkInterfaceWrapper>().ToArray();
+        }
+    }
+}

--- a/src/reyna/Reyna/Power/IPowerManager.cs
+++ b/src/reyna/Reyna/Power/IPowerManager.cs
@@ -1,11 +1,7 @@
-﻿using Reyna.Power;
-using System;
-
-namespace Reyna.Interfaces
+﻿namespace Reyna.Interfaces
 {
     public interface IPowerManager
     {
-        bool IsBatteryCharging();
-        SystemPowerStatus SystemPowerStatus { get; }
+        bool IsPowerLineConnected();
     }
 }

--- a/src/reyna/Reyna/Power/IPowerStatusWrapper.cs
+++ b/src/reyna/Reyna/Power/IPowerStatusWrapper.cs
@@ -1,0 +1,9 @@
+using System.Windows.Forms;
+
+namespace Reyna.Power
+{
+    public interface IPowerStatusWrapper
+    {
+        PowerLineStatus PowerLineStatus { get; }
+    }
+}

--- a/src/reyna/Reyna/Power/PowerManager.cs
+++ b/src/reyna/Reyna/Power/PowerManager.cs
@@ -8,9 +8,9 @@ namespace Reyna.Power
     {
         private readonly IPowerStatusWrapper _powerStatusWrapper;
 
-        public PowerManager(IPowerStatusWrapper powerStatusWrapper)
+        public PowerManager(IPowerStatusWrapper powerStatusWrapper = null)
         {
-            _powerStatusWrapper = powerStatusWrapper;
+            _powerStatusWrapper = powerStatusWrapper ?? new PowerStatusWrapper();
         }
 
         public bool IsPowerLineConnected()

--- a/src/reyna/Reyna/Power/PowerManager.cs
+++ b/src/reyna/Reyna/Power/PowerManager.cs
@@ -8,27 +8,14 @@ namespace Reyna.Power
     {
         private readonly IPowerStatusWrapper _powerStatusWrapper;
 
-        public PowerManager(IPowerStatusWrapper powerStatusWrapper = null)
+        public PowerManager(IPowerStatusWrapper powerStatusWrapper)
         {
-            _powerStatusWrapper = powerStatusWrapper ?? new PowerStatusWrapper();
+            _powerStatusWrapper = powerStatusWrapper;
         }
 
         public bool IsPowerLineConnected()
         {
             return _powerStatusWrapper.PowerLineStatus.Equals(PowerLineStatus.Online);
-        }
-    }
-
-    public interface IPowerStatusWrapper
-    {
-        PowerLineStatus PowerLineStatus { get; }
-    }
-
-    public class PowerStatusWrapper : IPowerStatusWrapper
-    {
-        public PowerLineStatus PowerLineStatus
-        {
-            get { return SystemInformation.PowerStatus.PowerLineStatus; }
         }
     }
 }

--- a/src/reyna/Reyna/Power/PowerManager.cs
+++ b/src/reyna/Reyna/Power/PowerManager.cs
@@ -1,37 +1,34 @@
-﻿namespace Reyna.Power
+﻿using System.Windows.Forms;
+
+namespace Reyna.Power
 {
-    using Reyna.Interfaces;
+    using Interfaces;
 
     public class PowerManager : IPowerManager
     {
-        public const byte Online = 0x01;
+        private readonly IPowerStatusWrapper _powerStatusWrapper;
 
-        public SystemPowerStatus SystemPowerStatus
+        public PowerManager(IPowerStatusWrapper powerStatusWrapper)
         {
-            get
-            {
-                var systemPowerStatus = new SystemPowerStatus();
-                if (NativeMethods.GetSystemPowerStatusEx(systemPowerStatus, 0) == 1)
-                {
-                    return systemPowerStatus;
-                }
-
-                return null;
-            }
+            _powerStatusWrapper = powerStatusWrapper;
         }
 
-        public bool IsBatteryCharging()
+        public bool IsPowerLineConnected()
         {
-            var systemPowerStatus = this.SystemPowerStatus;
-            if (systemPowerStatus != null)
-            {
-                if (systemPowerStatus.ACLineStatus.Equals(PowerManager.Online))
-                {
-                    return true;
-                }
-            }
+            return _powerStatusWrapper.PowerLineStatus.Equals(PowerLineStatus.Online);
+        }
+    }
 
-            return false;
+    public interface IPowerStatusWrapper
+    {
+        PowerLineStatus PowerLineStatus { get; }
+    }
+
+    public class PowerStatusWrapper : IPowerStatusWrapper
+    {
+        public PowerLineStatus PowerLineStatus
+        {
+            get { return SystemInformation.PowerStatus.PowerLineStatus; }
         }
     }
 }

--- a/src/reyna/Reyna/Power/PowerStatusWrapper.cs
+++ b/src/reyna/Reyna/Power/PowerStatusWrapper.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace Reyna.Power
+{
+    public class PowerStatusWrapper : IPowerStatusWrapper
+    {
+        public PowerLineStatus PowerLineStatus
+        {
+            get { return SystemInformation.PowerStatus.PowerLineStatus; }
+        }
+    }
+}

--- a/src/reyna/Reyna/Preferences/Preferences.cs
+++ b/src/reyna/Reyna/Preferences/Preferences.cs
@@ -6,6 +6,7 @@
     public class Preferences : IPreferences
     {
         private readonly IRegistry _registry;
+
         private const string SubKey = @"Software\Reyna";
         private const string StorageSizeLimitKeyName = "StorageSizeLimit";
         private const string WlanBlackoutRangeKeyName = "WlanBlackoutRange";
@@ -18,9 +19,9 @@
         private const string TemporaryErrorBackout = "TemporaryErrorBackout";
         private const string MessageBackout = "MessageBackout";
 
-        public Preferences(IRegistry registry = null)
+        public Preferences(IRegistry registry)
         {
-            _registry = registry ?? new Registry();
+            _registry = registry;
         }
 
         public TimeRange CellularDataBlackout

--- a/src/reyna/Reyna/Preferences/Preferences.cs
+++ b/src/reyna/Reyna/Preferences/Preferences.cs
@@ -18,9 +18,9 @@
         private const string TemporaryErrorBackout = "TemporaryErrorBackout";
         private const string MessageBackout = "MessageBackout";
 
-        public Preferences(IRegistry registry)
+        public Preferences(IRegistry registry = null)
         {
-            _registry = registry;
+            _registry = registry ?? new Registry();
         }
 
         public TimeRange CellularDataBlackout

--- a/src/reyna/Reyna/Preferences/Preferences.cs
+++ b/src/reyna/Reyna/Preferences/Preferences.cs
@@ -2,10 +2,10 @@
 {
     using System;
     using System.Text.RegularExpressions;
-    using Microsoft.Win32;
 
     public class Preferences : IPreferences
     {
+        private readonly IRegistry _registry;
         private const string SubKey = @"Software\Reyna";
         private const string StorageSizeLimitKeyName = "StorageSizeLimit";
         private const string WlanBlackoutRangeKeyName = "WlanBlackoutRange";
@@ -17,6 +17,11 @@
         private const string DataBlackoutToKeyName = "DataBlackout:To";
         private const string TemporaryErrorBackout = "TemporaryErrorBackout";
         private const string MessageBackout = "MessageBackout";
+
+        public Preferences(IRegistry registry)
+        {
+            _registry = registry;
+        }
 
         public TimeRange CellularDataBlackout
         {
@@ -205,8 +210,7 @@
 
         public void SaveCellularDataAsWwanForBackwardsCompatibility()
         {
-            Preferences preferences = new Preferences();
-            TimeRange timeRange = preferences.CellularDataBlackout;
+            TimeRange timeRange = CellularDataBlackout;
             if (timeRange != null)
             {
                 int hourFrom = (int)Math.Floor((double)timeRange.From.MinuteOfDay / 60);
@@ -217,7 +221,7 @@
                 int minuteTo = timeRange.To.MinuteOfDay % 60;
                 string blackoutTo = ZeroPad(hourTo) + ":" + ZeroPad(minuteTo);
 
-                preferences.SetWwanBlackoutRange(blackoutFrom + "-" + blackoutTo);
+                SetWwanBlackoutRange(blackoutFrom + "-" + blackoutTo);
             }
         }
 
@@ -231,49 +235,49 @@
             DeleteRegistryValue(StorageSizeLimitKeyName);
         }
 
-        private static long GetRegistryValue(string keyName, long defaultValue)
+        private long GetRegistryValue(string keyName, long defaultValue)
         {
-            return new Registry().GetQWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue);
+            return _registry.GetQWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue);
         }
 
-        private static int GetRegistryValue(string keyName, int defaultValue)
+        private int GetRegistryValue(string keyName, int defaultValue)
         {
-            return new Registry().GetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue);
+            return _registry.GetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue);
         }
 
-        private static bool GetRegistryValue(string keyName, bool defaultValue)
+        private bool GetRegistryValue(string keyName, bool defaultValue)
         {
-            return new Registry().GetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue ? 1 : 0) == 1;
+            return _registry.GetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue ? 1 : 0) == 1;
         }
 
-        private static string GetRegistryValue(string keyName, string defaultValue)
+        private string GetRegistryValue(string keyName, string defaultValue)
         {
-            return new Registry().GetString(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue);
+            return _registry.GetString(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, defaultValue);
         }
 
-        private static void SetRegistryValue(string keyName, long value)
+        private void SetRegistryValue(string keyName, long value)
         {
-            new Registry().SetQWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value);
+            _registry.SetQWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value);
         }
 
-        private static void SetRegistryValue(string keyName, string value)
+        private void SetRegistryValue(string keyName, string value)
         {
-            new Registry().SetString(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value);
+            _registry.SetString(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value);
         }
 
-        private static void SetRegistryValue(string keyName, bool value)
+        private void SetRegistryValue(string keyName, bool value)
         {
-            new Registry().SetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value ? 1 : 0);
+            _registry.SetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value ? 1 : 0);
         }
 
-        private static void SetRegistryValue(string keyName, int value)
+        private void SetRegistryValue(string keyName, int value)
         {
-            new Registry().SetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value);
+            _registry.SetDWord(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName, value);
         }
 
-        private static void DeleteRegistryValue(string keyName)
+        private void DeleteRegistryValue(string keyName)
         {
-            new Registry().DeleteValue(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName);
+            _registry.DeleteValue(Microsoft.Win32.Registry.LocalMachine, SubKey, keyName);
         }
 
         private static object ZeroPad(int numToPad)

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Reyna</RootNamespace>
     <AssemblyName>Reyna</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -73,14 +74,17 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Windows.Networking" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Blackout\BlackoutTime.cs" />
     <Compile Include="Blackout\IBlackoutTime.cs" />
     <Compile Include="Blackout\Time.cs" />
     <Compile Include="Blackout\TimeRange.cs" />
+    <Compile Include="Connection\ConnectionCost.cs" />
     <Compile Include="Connection\ConnectionInfo.cs" />
     <Compile Include="Connection\ConnectionManager.cs" />
+    <Compile Include="Connection\IConnectionCost.cs" />
     <Compile Include="Connection\IConnectionInfo.cs" />
     <Compile Include="Connection\IConnectionManager.cs" />
     <Compile Include="Extensions\HttpStatusCodeExtensions.cs" />
@@ -92,7 +96,9 @@
     <Compile Include="Logging\ILogDelegate.cs" />
     <Compile Include="NativeMethods\NativeMethods.cs" />
     <Compile Include="Network\INetwork.cs" />
+    <Compile Include="Network\INetworkInterfaceWrapper.cs" />
     <Compile Include="Network\Network.cs" />
+    <Compile Include="Network\NetworkInterfaceWrapper.cs" />
     <Compile Include="Power\IPowerManager.cs" />
     <Compile Include="Power\PowerManager.cs" />
     <Compile Include="Power\SystemPowerStatus.cs" />

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -97,8 +97,10 @@
     <Compile Include="NativeMethods\NativeMethods.cs" />
     <Compile Include="Network\INetwork.cs" />
     <Compile Include="Network\INetworkInterfaceWrapper.cs" />
+    <Compile Include="Network\INetworkInterfaceWrapperFactory.cs" />
     <Compile Include="Network\Network.cs" />
     <Compile Include="Network\NetworkInterfaceWrapper.cs" />
+    <Compile Include="Network\NetworkInterfaceWrapperFactory.cs" />
     <Compile Include="Power\IPowerManager.cs" />
     <Compile Include="Power\PowerManager.cs" />
     <Compile Include="Power\SystemPowerStatus.cs" />

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -102,7 +102,9 @@
     <Compile Include="Network\NetworkInterfaceWrapper.cs" />
     <Compile Include="Network\NetworkInterfaceWrapperFactory.cs" />
     <Compile Include="Power\IPowerManager.cs" />
+    <Compile Include="Power\IPowerStatusWrapper.cs" />
     <Compile Include="Power\PowerManager.cs" />
+    <Compile Include="Power\PowerStatusWrapper.cs" />
     <Compile Include="Power\SystemPowerStatus.cs" />
     <Compile Include="Preferences\IPreferences.cs" />
     <Compile Include="Preferences\IRegistry.cs" />

--- a/src/reyna/Reyna/Reyna.csproj
+++ b/src/reyna/Reyna/Reyna.csproj
@@ -67,6 +67,7 @@
       <HintPath>..\packages\System.Data.SQLite.Linq.1.0.98.1\lib\net45\System.Data.SQLite.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/reyna/Reyna/Services/IReyna.cs
+++ b/src/reyna/Reyna/Services/IReyna.cs
@@ -5,5 +5,10 @@ namespace Reyna.Interfaces
     {
         void Put(IMessage message);
         void EnableLogging(ILogDelegate llog);
+        void SetWlanBlackoutRange(string ranges);
+        void SetWwanBlackoutRange(string ranges);
+        void SetRoamingBlackout(bool blackout);
+        void SetOnChargeBlackout(bool blackout);
+        void SetOffChargeBlackout(bool blackout);
     }
 }

--- a/src/reyna/Reyna/Services/ReynaService.cs
+++ b/src/reyna/Reyna/Services/ReynaService.cs
@@ -19,36 +19,32 @@ namespace Reyna
         internal IReynaLogger Logger { get; set; }
         
         internal byte[] Password { get; set; }
-
-        public ReynaService() : this(null)
-        {
-        }
-
-        public ReynaService(byte[] password) : this(password, UnityHelper.GetContainer())
+        
+        public ReynaService(byte[] password = null) : this(password, UnityHelper.GetContainer())
         {
         }
 
         internal ReynaService(byte[] password, IUnityContainer container)
         {
-            this.HttpClient = container.Resolve<IHttpClient>();
-            this.Preferences = container.Resolve<IPreferences>();
-            this.VolatileStore = container.Resolve<IRepository>(Constants.Injection.VOLATILE_STORE);
-            this.PersistentStore = container.Resolve<IRepository>(Constants.Injection.SQLITE_STORE);
-            this.NetworkStateService = container.Resolve<INetworkStateService>();
-            this.StoreService = container.Resolve<IStoreService>();
-            this.ForwardService = container.Resolve<IForwardService>();
-            this.EncryptionChecker = container.Resolve<IEncryptionChecker>();
+            HttpClient = container.Resolve<IHttpClient>();
+            Preferences = container.Resolve<IPreferences>();
+            VolatileStore = container.Resolve<IRepository>(Constants.Injection.VOLATILE_STORE);
+            PersistentStore = container.Resolve<IRepository>(Constants.Injection.SQLITE_STORE);
+            NetworkStateService = container.Resolve<INetworkStateService>();
+            StoreService = container.Resolve<IStoreService>();
+            ForwardService = container.Resolve<IForwardService>();
+            EncryptionChecker = container.Resolve<IEncryptionChecker>();
 
-            this.Logger = container.Resolve<IReynaLogger>();
+            Logger = container.Resolve<IReynaLogger>();
 
-            this.StoreService.Initialize(this.VolatileStore, this.PersistentStore);
-            this.ForwardService.Initialize(this.PersistentStore, this.HttpClient, this.NetworkStateService, this.Preferences.ForwardServiceTemporaryErrorBackout, this.Preferences.ForwardServiceMessageBackout);
+            StoreService.Initialize(VolatileStore, PersistentStore);
+            ForwardService.Initialize(PersistentStore, HttpClient, NetworkStateService, Preferences.ForwardServiceTemporaryErrorBackout, Preferences.ForwardServiceMessageBackout);
                                             
-            this.Password = password;
+            Password = password;
 
             if (password != null)
             {
-                this.PersistentStore.Password = password;
+                PersistentStore.Password = password;
             }
         }
 
@@ -56,74 +52,74 @@ namespace Reyna
         {
             get
             {
-                return this.Preferences.StorageSizeLimit;
+                return Preferences.StorageSizeLimit;
             }
         }
 
         public void SetStorageSizeLimit(long limit)
         {
             limit = limit < MinimumStorageLimit ? MinimumStorageLimit : limit;
-            this.Preferences.SetStorageSizeLimit(limit);
+            Preferences.SetStorageSizeLimit(limit);
 
-            this.PersistentStore.Initialise();
-            this.PersistentStore.ShrinkDb(limit);
+            PersistentStore.Initialise();
+            PersistentStore.ShrinkDb(limit);
         }
 
         internal void ResetStorageSizeLimit()
         {
-            this.Preferences.ResetStorageSizeLimit();
+            Preferences.ResetStorageSizeLimit();
         }
 
         public void SetCellularDataBlackout(TimeRange timeRange)
         {
-            this.Preferences.SetCellularDataBlackout(timeRange);
+            Preferences.SetCellularDataBlackout(timeRange);
         }
 
         public void ResetCellularDataBlackout()
         {
-            this.Preferences.ResetCellularDataBlackout();
+            Preferences.ResetCellularDataBlackout();
         }
 
         public void SetWlanBlackoutRange(string range)
         {
-            this.Preferences.SetWlanBlackoutRange(range);
+            Preferences.SetWlanBlackoutRange(range);
         }
 
         public void SetWwanBlackoutRange(string range)
         {
-            this.Preferences.SetWwanBlackoutRange(range);
+            Preferences.SetWwanBlackoutRange(range);
         }
 
         public void SetRoamingBlackout(bool value)
         {
-            this.Preferences.SetRoamingBlackout(value);
+            Preferences.SetRoamingBlackout(value);
         }
 
         public void SetOnChargeBlackout(bool value)
         {
-            this.Preferences.SetOnChargeBlackout(value);
+            Preferences.SetOnChargeBlackout(value);
         }
 
         public void SetOffChargeBlackout(bool value)
         {
-            this.Preferences.SetOffChargeBlackout(value);
+            Preferences.SetOffChargeBlackout(value);
         }
 
         public void Start()
         {
             Logger.Info("Reyna.ReynaService Start enter");  
           
-            if (this.Password != null && this.Password.Length > 0)
+            if (Password != null && Password.Length > 0)
             {
-                if (!this.EncryptionChecker.DbEncrypted())
+                if (!EncryptionChecker.DbEncrypted())
                 {
-                    this.EncryptionChecker.EncryptDb(this.Password);
+                    EncryptionChecker.EncryptDb(Password);
                 }
             }
 
-            this.StoreService.Start();
-            this.ForwardService.Start();
-            this.NetworkStateService.Start();
+            StoreService.Start();
+            ForwardService.Start();
+            NetworkStateService.Start();
 
             Logger.Info("Reyna.ReynaService Start exit");   
         }
@@ -132,16 +128,16 @@ namespace Reyna
         {
             Logger.Info("Reyna.ReynaService Stop enter");  
 
-            this.NetworkStateService.Stop();
-            this.ForwardService.Stop();
-            this.StoreService.Stop();
+            NetworkStateService.Stop();
+            ForwardService.Stop();
+            StoreService.Stop();
             
             Logger.Info("Reyna.ReynaService Stop exit");  
         }
 
         public void Put(IMessage message)
         {
-            this.VolatileStore.Add(message);
+            VolatileStore.Add(message);
         }
 
         public void EnableLogging(ILogDelegate logDelegate)
@@ -152,19 +148,19 @@ namespace Reyna
 
         public void Dispose()
         {
-            if (this.NetworkStateService != null)
+            if (NetworkStateService != null)
             {
-                this.NetworkStateService.Dispose();
+                NetworkStateService.Dispose();
             }
 
-            if (this.ForwardService != null)
+            if (ForwardService != null)
             {
-                this.ForwardService.Dispose();
+                ForwardService.Dispose();
             }
 
-            if (this.StoreService != null)
+            if (StoreService != null)
             {
-                this.StoreService.Dispose();
+                StoreService.Dispose();
             }
         }
     }

--- a/src/reyna/Reyna/UnityHelper.cs
+++ b/src/reyna/Reyna/UnityHelper.cs
@@ -28,6 +28,7 @@ namespace Reyna
             container.RegisterType<IWebRequest, ReynaWebRequest>();
             container.RegisterType<INetworkInterfaceWrapper, NetworkInterfaceWrapper>();
             container.RegisterType<INetworkInterfaceWrapperFactory, NetworkInterfaceWrapperFactory>();
+            container.RegisterType<IPowerStatusWrapper, PowerStatusWrapper>();
 
             container.RegisterInstance<IReynaLogger>(new ReynaLogger());
 

--- a/src/reyna/Reyna/UnityHelper.cs
+++ b/src/reyna/Reyna/UnityHelper.cs
@@ -29,6 +29,7 @@ namespace Reyna
             container.RegisterType<INetworkInterfaceWrapper, NetworkInterfaceWrapper>();
             container.RegisterType<INetworkInterfaceWrapperFactory, NetworkInterfaceWrapperFactory>();
             container.RegisterType<IPowerStatusWrapper, PowerStatusWrapper>();
+            container.RegisterType<IRegistry, Registry>();
 
             container.RegisterInstance<IReynaLogger>(new ReynaLogger());
 

--- a/src/reyna/Reyna/UnityHelper.cs
+++ b/src/reyna/Reyna/UnityHelper.cs
@@ -1,15 +1,9 @@
-﻿
+﻿using Microsoft.Practices.Unity;
+using Reyna.Interfaces;
+using Reyna.Power;
+
 namespace Reyna
 {
-    using Microsoft.Practices.Unity;
-    using Reyna.Interfaces;
-    using Reyna.Power;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    
     internal static class UnityHelper
     {
         internal static IUnityContainer GetContainer()
@@ -32,6 +26,8 @@ namespace Reyna
             container.RegisterType<IConnectionInfo, ConnectionInfo>();
             container.RegisterType<IBlackoutTime, BlackoutTime>();
             container.RegisterType<IWebRequest, ReynaWebRequest>();
+            container.RegisterType<INetworkInterfaceWrapper, NetworkInterfaceWrapper>();
+            container.RegisterType<INetworkInterfaceWrapperFactory, NetworkInterfaceWrapperFactory>();
 
             container.RegisterInstance<IReynaLogger>(new ReynaLogger());
 

--- a/src/reyna/Reyna/UnityHelper.cs
+++ b/src/reyna/Reyna/UnityHelper.cs
@@ -28,6 +28,7 @@ namespace Reyna
             container.RegisterType<IWebRequest, ReynaWebRequest>();
             container.RegisterType<INetworkInterfaceWrapper, NetworkInterfaceWrapper>();
             container.RegisterType<INetworkInterfaceWrapperFactory, NetworkInterfaceWrapperFactory>();
+            container.RegisterType<IConnectionCost, ConnectionCost>();
             container.RegisterType<IPowerStatusWrapper, PowerStatusWrapper>();
             container.RegisterType<IRegistry, Registry>();
 


### PR DESCRIPTION
Implements the battery/power on charge or off charge as well as roaming (uses winRT so roaming only works for windows 8+ devices, the likely hood of a device of a lesser version than this being capable of roaming is small so it's probably not a huge deal). Adds a couple of extra mobile network interfaces to check for too.

This is needed for restricting data upload on x86/x64 devices under certain conditions.

Also spruces up some naughty unit tests that were using the real registry - now it's mocked.
